### PR TITLE
Changes behaviour of timeout

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -59,7 +59,7 @@ var (
 	c = flag.Int("c", 50, "")
 	n = flag.Int("n", 200, "")
 	q = flag.Int("q", 0, "")
-	t = flag.Int("t", 0, "")
+	t = flag.Int("t", 20, "")
 
 	h2 = flag.Bool("h2", false, "")
 
@@ -86,7 +86,7 @@ Options:
   -m  HTTP method, one of GET, POST, PUT, DELETE, HEAD, OPTIONS.
   -H  Custom HTTP header. You can specify as many as needed by repeating the flag.
       for example, -H "Accept: text/html" -H "Content-Type: application/xml" .
-  -t  Timeout in ms.
+  -t  Timeout in seconds. Default is 20, use 0 to disable.
   -A  HTTP Accept header.
   -d  HTTP request body.
   -T  Content-type, defaults to "text/html".
@@ -101,7 +101,7 @@ Options:
   -cpus                 Number of used cpu cores.
                         (default for current machine is %d cores)
   -host                 HTTP Host header.
-  -more                 Provides information on DNS lookup, dialup, request and response timings.  
+  -more                 Provides information on DNS lookup, dialup, request and response timings.
 `
 
 func main() {

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -174,16 +174,14 @@ func (b *Work) runWorker(n int) {
 		},
 		DisableCompression: b.DisableCompression,
 		DisableKeepAlives:  b.DisableKeepAlives,
-		// TODO(jbd): Add dial timeout.
-		TLSHandshakeTimeout: time.Duration(b.Timeout) * time.Millisecond,
-		Proxy:               http.ProxyURL(b.ProxyAddr),
+		Proxy:              http.ProxyURL(b.ProxyAddr),
 	}
 	if b.H2 {
 		http2.ConfigureTransport(tr)
 	} else {
 		tr.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
 	}
-	client := &http.Client{Transport: tr}
+	client := &http.Client{Transport: tr, Timeout: time.Duration(b.Timeout) * time.Second}
 	for i := 0; i < n; i++ {
 		if b.Qps > 0 {
 			<-throttle


### PR DESCRIPTION
Hey (no phun intended)

This PR changes the behaviour of timeouts. Instead of checking for timeout on TLSHandshake/dial this sets the timeout for http.Client which includes both. Changed the default value from 0 to 20 and went from ms to s which seems easier to handle for the human using hey.

Not sure if this is the way you want to go, if not you can just ignore this PR. :)

My editor also fixed some trailing whitespaces