### PR TITLE
Rename inconsistent initialisms

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -194,7 +194,7 @@ func main() {
 		RequestBody:        *body,
 		N:                  num,
 		C:                  conc,
-		Qps:                q,
+		QPS:                q,
 		Timeout:            *t,
 		DisableCompression: *disableCompression,
 		DisableKeepAlives:  *disableKeepAlives,

--- a/requester/print.go
+++ b/requester/print.go
@@ -34,7 +34,7 @@ type report struct {
 
 	trace    bool //if trace is set, the following fields will be filled
 	avgConn  float64
-	avgDns   float64
+	avgDNS   float64
 	avgReq   float64
 	avgRes   float64
 	avgDelay float64
@@ -73,7 +73,7 @@ func (r *report) finalize() {
 				if r.trace {
 					r.avgConn += res.connDuration.Seconds()
 					r.avgDelay += res.delayDuration.Seconds()
-					r.avgDns += res.dnsDuration.Seconds()
+					r.avgDNS += res.dnsDuration.Seconds()
 					r.avgReq += res.reqDuration.Seconds()
 					r.avgRes += res.resDuration.Seconds()
 				}
@@ -88,7 +88,7 @@ func (r *report) finalize() {
 			if r.trace {
 				r.avgConn = r.avgConn / float64(len(r.lats))
 				r.avgDelay = r.avgDelay / float64(len(r.lats))
-				r.avgDns = r.avgDns / float64(len(r.lats))
+				r.avgDNS = r.avgDNS / float64(len(r.lats))
 				r.avgReq = r.avgReq / float64(len(r.lats))
 				r.avgRes = r.avgRes / float64(len(r.lats))
 			}
@@ -123,8 +123,8 @@ func (r *report) print() {
 		if r.trace {
 			fmt.Printf("\nHttpTrace:\n")
 			fmt.Printf("  DNS+dialup:\t\t%4.4f secs\n", r.avgConn)
-			if r.avgDns > 0 {
-				fmt.Printf("  DNS lookup:\t\t%4.4f secs\n", r.avgDns)
+			if r.avgDNS > 0 {
+				fmt.Printf("  DNS lookup:\t\t%4.4f secs\n", r.avgDNS)
 			}
 			fmt.Printf("  request Write:\t%4.4f secs\n", r.avgReq)
 			fmt.Printf("  response wait:\t%4.4f secs\n", r.avgDelay)

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -65,7 +65,7 @@ type Work struct {
 	Timeout int
 
 	// Qps is the rate limit.
-	Qps int
+	QPS int
 
 	// DisableCompression is an option to disable compression in response
 	DisableCompression bool
@@ -164,8 +164,8 @@ func (b *Work) makeRequest(c *http.Client) {
 
 func (b *Work) runWorker(n int) {
 	var throttle <-chan time.Time
-	if b.Qps > 0 {
-		throttle = time.Tick(time.Duration(1e6/(b.Qps)) * time.Microsecond)
+	if b.QPS > 0 {
+		throttle = time.Tick(time.Duration(1e6/(b.QPS)) * time.Microsecond)
 	}
 
 	tr := &http.Transport{
@@ -183,7 +183,7 @@ func (b *Work) runWorker(n int) {
 	}
 	client := &http.Client{Transport: tr, Timeout: time.Duration(b.Timeout) * time.Second}
 	for i := 0; i < n; i++ {
-		if b.Qps > 0 {
+		if b.QPS > 0 {
 			<-throttle
 		}
 		b.makeRequest(client)

--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -59,7 +59,7 @@ func TestQps(t *testing.T) {
 		Request: req,
 		N:       20,
 		C:       2,
-		Qps:     1,
+		QPS:     1,
 	}
 	wg.Add(1)
 	time.AfterFunc(time.Second, func() {


### PR DESCRIPTION
According to https://github.com/golang/go/wiki/CodeReviewComments#initialisms:

> Words in names that are initialisms or acronyms (e.g. "URL" or "NATO") have a consistent case. For example, "URL" should appear as "URL" or "url" (as in "urlPony", or "URLPony"), never as "Url". Here's an example: ServeHTTP not ServeHttp.
> 
> This rule also applies to "ID" when it is short for "identifier," so write "appID" instead of "appId".
> 
> Code generated by the protocol buffer compiler is exempt from this rule. Human-written code is held to a higher standard than machine-written code.
> 

Love Hey, by the way. :)