### PR TITLE
Add support for building snaps via snapcraft

### DIFF
--- a/snap/plugins/x-gobuild.yaml
+++ b/snap/plugins/x-gobuild.yaml
@@ -1,0 +1,6 @@
+options:
+    source:
+        required: true
+    source-type:
+    source-tag:
+    source-branch:

--- a/snap/plugins/x_gobuild.py
+++ b/snap/plugins/x_gobuild.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+import sys
+
+import snapcraft
+
+class XGobuildPlugin(snapcraft.BasePlugin):
+    def build(self):
+        env = os.environ.copy()
+
+        # All executables in a classic snap must be linked with special flags.
+        # Unfortunately, Go's ./make.bash does not respect the LDFLAGS
+        # environment variable and so we use a wrapper which does and tell Go to
+        # use that as the linker.
+        mycc = os.path.join(self.builddir, 'mycc')
+        with open(mycc, 'w') as script:
+            os.chmod(script.fileno(), 0o755)
+            script.write('#!/bin/bash\n')
+            script.write('set -ex\n')
+            script.write('exec gcc $LDFLAGS "$@"\n')
+        env['GO_LDFLAGS'] = '-linkmode=external -extld=%s'%(mycc,)
+
+        # Bootstrap with the go that is on the PATH.
+        goroot_bootstrap = subprocess.check_output(['go', 'env', 'GOROOT'])
+        env['GOROOT_BOOTSTRAP'] = goroot_bootstrap.decode(sys.getfilesystemencoding()).rstrip('\n')
+
+        self.run(['./make.bash'], cwd=os.path.join(self.builddir, 'src'), env=env)
+
+        # Remove our gcc wrapper.
+        os.unlink(mycc)
+
+        # Just ship the whole tree.
+        self.run(['rsync', '-a', '--exclude', '.git', self.builddir + '/', self.installdir])
+
+        # And finally, create a wrapper that sets $GOROOT based on $SNAP.
+        with open(os.path.join(self.installdir, 'gowrapper'), 'w') as script:
+            os.chmod(script.fileno(), 0o755)
+            script.write('#!/bin/bash\n')
+            script.write('export GOROOT="$SNAP"\n')
+            script.write('exec $SNAP/bin/go "$@"\n')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,6 @@ parts:
   hey:
     plugin: go
     after: [go17]
-    source: https://github.com/rakyll/hey
+    source: .
     source-type: git
     go-importpath: github.com/rakyll/hey

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: hey # you probably want to 'snapcraft register <name>'
+version: '0' # just for humans, typically '1.2+git' or '1.3.2'
+summary: HTTP load generator, ApacheBench (ab) replacement, formerly rakyll/boom
+description: |
+  hey is a tiny program that sends some load to a web application.
+  hey was originally called boom and was influenced from Tarek Ziade's tool at
+  tarekziade/boom. Using the same name was a mistake as it resulted in cases
+  where binary name conflicts created confusion. To preserve the name for its
+  original owner, we renamed this project to hey.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+apps:
+  hey:
+    command: hey
+    plugs:
+      - network
+
+parts:
+  go17:
+    plugin: x-gobuild
+    build-packages: [golang-go]
+    source: https://go.googlesource.com/go
+    source-type: git
+    source-tag: go1.7.5
+    prime:
+      - -*
+  hey:
+    plugin: go
+    after: [go17]
+    source: https://github.com/rakyll/hey
+    source-type: git
+    go-importpath: github.com/rakyll/hey


### PR DESCRIPTION
This PR adds support for building a snap of hey using snapcraft. You can find out more about snapcraft at https://snapcraft.io/

This consists of a yaml which describes the hey snap, and a plugin for snapcraft which builds go 1.7 that is required by hey. 

To build on an Ubuntu 16.04 system:-

  ```
sudo apt install snapcraft
git clone http://github.com/popey/hey
cd hey
git checkout add-snapcraft
snapcraft
```

This will build hey. You can install and test thus:-

`snap install *.snap --dangerous`

The "--dangerous" option is required when installing untrusted packages. Users installing signed packages from the store don't need that.

Once built the snap can be uploaded to the snap store as per the documentation:-

https://snapcraft.io/docs/build-snaps/publish

It would also be great to automatically push on each commit to the 'edge' channel in the store using travis or launchpad. 

https://snapcraft.io/docs/build-snaps/ci-integration