### PR TITLE
preset ContentLength in first http.Request

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -195,6 +195,7 @@ func main() {
 	if err != nil {
 		usageAndExit(err.Error())
 	}
+	req.ContentLength = int64(len(bodyAll))
 	req.Header = header
 	if username != "" || password != "" {
 		req.SetBasicAuth(username, password)


### PR DESCRIPTION
`http.NewRequest(method, url, body)` usually handles `req.ContentLength`, but body is initially passed as nil so we must calculate it since cloneRequest handles populating new req.Body readers later on.

Fixes #36.