### PR TITLE
Allow more precision in the QPS parameter

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -60,7 +60,7 @@ var (
 
 	c = flag.Int("c", 50, "")
 	n = flag.Int("n", 200, "")
-	q = flag.Int("q", 0, "")
+	q = flag.Float64("q", 0, "")
 	t = flag.Int("t", 20, "")
 
 	h2 = flag.Bool("h2", false, "")
@@ -80,7 +80,7 @@ Options:
   -n  Number of requests to run. Default is 200.
   -c  Number of requests to run concurrently. Total number of requests cannot
       be smaller than the concurrency level. Default is 50.
-  -q  Rate limit, in seconds (QPS).
+  -q  Rate limit, in queries per second (QPS). Default is no rate limit.
   -o  Output type. If none provided, a summary is printed.
       "csv" is the only supported alternative. Dumps the response
       metrics in comma-separated values format.

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -67,8 +67,8 @@ type Work struct {
 	// Timeout in seconds.
 	Timeout int
 
-	// Qps is the rate limit.
-	QPS int
+	// Qps is the rate limit in queries per second.
+	QPS float64
 
 	// DisableCompression is an option to disable compression in response
 	DisableCompression bool
@@ -215,7 +215,7 @@ func (b *Work) makeRequest(c *http.Client) {
 
 func (b *Work) runWorker(n int) {
 	var throttle <-chan time.Time
-	if b.QPS > 0 {
+	if b.QPS > 0.0 {
 		throttle = time.Tick(time.Duration(1e6/(b.QPS)) * time.Microsecond)
 	}
 


### PR DESCRIPTION
In some (rare) use cases, such as mine, the focus is on long running benchmarks with infrequent requests. For that reason I need QPS to be allowed to be a float to be able to specify 1 > QPS > 0. In other cases it might be useful to be able to specify the QPS to a more precise value.

Given that there is no reason (as far as I can see) to solely allow int-based QPS, I propose to switch the parameter to allow floats as well.