### PR TITLE
Remove references to -more option to enable tracing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Options:
                         connections between different HTTP requests.
   -cpus                 Number of used cpu cores.
                         (default for current machine is 8 cores)
-  -more                 Provides information on DNS lookup, dialup, request and
-                        response timings.
 ```
 
 Previously known as [github.com/rakyll/boom](https://github.com/rakyll/boom).

--- a/hey.go
+++ b/hey.go
@@ -93,8 +93,6 @@ Options:
   -disable-redirects    Disable following of HTTP redirects
   -cpus                 Number of used cpu cores.
                         (default for current machine is %d cores)
-  -more                 Provides information on DNS lookup, dialup, request and
-                        response timings.
 `
 
 func main() {


### PR DESCRIPTION
After tracing was enabled by default the reference to the `-more` option in the README and `hey.go` was left in place. As a new user of this tool it created some confusion. 