### PR TITLE
Add SOCKS5 proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
   -T  Content-type, defaults to "text/html".
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
+  -s  SOCKS5 Proxy address as host:port.
   -h2 Enable HTTP/2.
 
   -host	HTTP Host header.

--- a/hey.go
+++ b/hey.go
@@ -30,7 +30,7 @@ import (
 
 	"golang.org/x/net/proxy"
 
-	"github.com/mmcloughlin/hey/requester"
+	"github.com/rakyll/hey/requester"
 )
 
 const (

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
@@ -77,6 +78,9 @@ type Work struct {
 	// Output represents the output type. If "csv" is provided, the
 	// output will be dumped as a csv stream.
 	Output string
+
+	// Dial is a dialer for the underlying Transport. Optional.
+	Dial func(network, addr string) (net.Conn, error)
 
 	// ProxyAddr is the address of HTTP proxy server in the format on "host:port".
 	// Optional.
@@ -184,6 +188,7 @@ func (b *Work) runWorker(n int) {
 	}
 
 	tr := &http.Transport{
+		Dial: b.Dial,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},


### PR DESCRIPTION
I wanted to use `hey` to do some tor performance testing, so I added SOCKS5 proxy support using the `golang.org/x/net/proxy` module. Perhaps this is useful to others.