### PR TITLE
Add server name to TLS parameters

### DIFF
--- a/requester/requester.go
+++ b/requester/requester.go
@@ -219,6 +219,7 @@ func (b *Work) runWorkers() {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
+			ServerName:         b.Request.Host,
 		},
 		MaxIdleConnsPerHost: min(b.C, maxIdleConn),
 		DisableCompression:  b.DisableCompression,


### PR DESCRIPTION
In certain cases when you're requesting against a proxy or load balancer
that does TLS it's required to also pass in the `ServerName` in order
for the TLS handshake to work correctly.

This PR simply uses `Request.Host` to transfer that knowledge, which
ultimately comes from `-host <host>`.