### PR TITLE
Make result channel bounded by a reasonable value, not N. Incremental…

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -211,7 +211,7 @@ func main() {
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		<-c
-		fmt.Println("\nInterrupted, stopping workers.")
+		fmt.Fprintf(os.Stderr, "\nInterrupted, stopping workers.")
 		w.Stop()
 	}()
 	w.Run()

--- a/hey.go
+++ b/hey.go
@@ -211,7 +211,8 @@ func main() {
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		<-c
-		w.Interrupt()
+		fmt.Println("\nInterrupted, stopping workers.")
+		w.Stop()
 	}()
 	w.Run()
 }

--- a/hey.go
+++ b/hey.go
@@ -211,8 +211,7 @@ func main() {
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		<-c
-		w.Finish()
-		os.Exit(1)
+		w.Interrupt()
 	}()
 	w.Run()
 }

--- a/requester/print.go
+++ b/requester/print.go
@@ -26,6 +26,9 @@ const (
 	barChar = "∎"
 )
 
+// We report for max 1M results.
+const maxRes = 1000000
+
 type report struct {
 	avgTotal float64
 	fastest  float64
@@ -45,52 +48,73 @@ type report struct {
 	delayLats []float64
 
 	results chan *result
+	done    chan bool
 	total   time.Duration
 
 	errorDist      map[string]int
 	statusCodeDist map[int]int
 	lats           []float64
 	sizeTotal      int64
-
-	output string
+	n              int
+	output         string
 
 	w io.Writer
 }
 
-func newReport(w io.Writer, size int, results chan *result, output string, total time.Duration) *report {
+func newReport(w io.Writer, results chan *result, output string, n int) *report {
+	cap := n
+	if n > maxRes {
+		cap = maxRes
+	}
 	return &report{
 		output:         output,
 		results:        results,
-		total:          total,
+		done:           make(chan bool, 1),
 		statusCodeDist: make(map[int]int),
 		errorDist:      make(map[string]int),
 		w:              w,
+		n:              n,
+		connLats:       make([]float64, 0, cap),
+		dnsLats:        make([]float64, 0, cap),
+		reqLats:        make([]float64, 0, cap),
+		resLats:        make([]float64, 0, cap),
+		delayLats:      make([]float64, 0, cap),
+		lats:           make([]float64, 0, cap),
 	}
 }
 
-func (r *report) finalize() {
+func runReporter(r *report) {
+	// Loop will continue until channel is closed
 	for res := range r.results {
 		if res.err != nil {
 			r.errorDist[res.err.Error()]++
 		} else {
-			r.lats = append(r.lats, res.duration.Seconds())
 			r.avgTotal += res.duration.Seconds()
 			r.avgConn += res.connDuration.Seconds()
 			r.avgDelay += res.delayDuration.Seconds()
 			r.avgDNS += res.dnsDuration.Seconds()
 			r.avgReq += res.reqDuration.Seconds()
 			r.avgRes += res.resDuration.Seconds()
-			r.connLats = append(r.connLats, res.connDuration.Seconds())
-			r.dnsLats = append(r.dnsLats, res.dnsDuration.Seconds())
-			r.reqLats = append(r.reqLats, res.reqDuration.Seconds())
-			r.delayLats = append(r.delayLats, res.delayDuration.Seconds())
-			r.resLats = append(r.resLats, res.resDuration.Seconds())
+			if len(r.resLats) < maxRes {
+				r.lats = append(r.lats, res.duration.Seconds())
+				r.connLats = append(r.connLats, res.connDuration.Seconds())
+				r.dnsLats = append(r.dnsLats, res.dnsDuration.Seconds())
+				r.reqLats = append(r.reqLats, res.reqDuration.Seconds())
+				r.delayLats = append(r.delayLats, res.delayDuration.Seconds())
+				r.resLats = append(r.resLats, res.resDuration.Seconds())
+			}
 			r.statusCodeDist[res.statusCode]++
 			if res.contentLength > 0 {
 				r.sizeTotal += res.contentLength
 			}
 		}
 	}
+	// Signal reporter is done.
+	r.done <- true
+}
+
+func (r *report) finalize(total time.Duration) {
+	r.total = total
 	r.rps = float64(len(r.lats)) / r.total.Seconds()
 	r.average = r.avgTotal / float64(len(r.lats))
 	r.avgConn = r.avgConn / float64(len(r.lats))
@@ -128,6 +152,9 @@ func (r *report) print() {
 		if r.sizeTotal > 0 {
 			r.printf("  Total data:\t%d bytes\n", r.sizeTotal)
 			r.printf("  Size/request:\t%d bytes\n", r.sizeTotal/int64(len(r.lats)))
+		}
+		if r.n > maxRes {
+			r.printf("\nNote:  Distributions are for first %d results.", maxRes)
 		}
 		r.printHistogram()
 		r.printLatencies()

--- a/requester/print.go
+++ b/requester/print.go
@@ -55,7 +55,7 @@ type report struct {
 	statusCodeDist map[int]int
 	lats           []float64
 	sizeTotal      int64
-	numReqs        int64
+	numRes         int64
 	output         string
 
 	w io.Writer
@@ -82,7 +82,7 @@ func newReport(w io.Writer, results chan *result, output string, n int) *report 
 func runReporter(r *report) {
 	// Loop will continue until channel is closed
 	for res := range r.results {
-		r.numReqs++
+		r.numRes++
 		if res.err != nil {
 			r.errorDist[res.err.Error()]++
 		} else {
@@ -112,7 +112,7 @@ func runReporter(r *report) {
 
 func (r *report) finalize(total time.Duration) {
 	r.total = total
-	r.rps = float64(r.numReqs) / r.total.Seconds()
+	r.rps = float64(r.numRes) / r.total.Seconds()
 	r.average = r.avgTotal / float64(len(r.lats))
 	r.avgConn = r.avgConn / float64(len(r.lats))
 	r.avgDelay = r.avgDelay / float64(len(r.lats))
@@ -150,7 +150,7 @@ func (r *report) print() {
 			r.printf("  Total data:\t%d bytes\n", r.sizeTotal)
 			r.printf("  Size/request:\t%d bytes\n", r.sizeTotal/int64(len(r.lats)))
 		}
-		if r.numReqs > maxRes {
+		if r.numRes > maxRes {
 			r.printf("\nNote:  Distributions are for first %d results.", len(r.lats))
 		}
 		r.printHistogram()

--- a/requester/print.go
+++ b/requester/print.go
@@ -55,7 +55,7 @@ type report struct {
 	statusCodeDist map[int]int
 	lats           []float64
 	sizeTotal      int64
-	n              int
+	numReqs        int64
 	output         string
 
 	w io.Writer
@@ -70,7 +70,6 @@ func newReport(w io.Writer, results chan *result, output string, n int) *report 
 		statusCodeDist: make(map[int]int),
 		errorDist:      make(map[string]int),
 		w:              w,
-		n:              n,
 		connLats:       make([]float64, 0, cap),
 		dnsLats:        make([]float64, 0, cap),
 		reqLats:        make([]float64, 0, cap),
@@ -83,6 +82,7 @@ func newReport(w io.Writer, results chan *result, output string, n int) *report 
 func runReporter(r *report) {
 	// Loop will continue until channel is closed
 	for res := range r.results {
+		r.numReqs++
 		if res.err != nil {
 			r.errorDist[res.err.Error()]++
 		} else {
@@ -112,7 +112,7 @@ func runReporter(r *report) {
 
 func (r *report) finalize(total time.Duration) {
 	r.total = total
-	r.rps = float64(len(r.lats)) / r.total.Seconds()
+	r.rps = float64(r.numReqs) / r.total.Seconds()
 	r.average = r.avgTotal / float64(len(r.lats))
 	r.avgConn = r.avgConn / float64(len(r.lats))
 	r.avgDelay = r.avgDelay / float64(len(r.lats))
@@ -150,7 +150,7 @@ func (r *report) print() {
 			r.printf("  Total data:\t%d bytes\n", r.sizeTotal)
 			r.printf("  Size/request:\t%d bytes\n", r.sizeTotal/int64(len(r.lats)))
 		}
-		if r.n > maxRes {
+		if r.numReqs > maxRes {
 			r.printf("\nNote:  Distributions are for first %d results.", len(r.lats))
 		}
 		r.printHistogram()

--- a/requester/print.go
+++ b/requester/print.go
@@ -151,7 +151,7 @@ func (r *report) print() {
 			r.printf("  Size/request:\t%d bytes\n", r.sizeTotal/int64(len(r.lats)))
 		}
 		if r.n > maxRes {
-			r.printf("\nNote:  Distributions are for first %d results.", maxRes)
+			r.printf("\nNote:  Distributions are for first %d results.", len(r.lats))
 		}
 		r.printHistogram()
 		r.printLatencies()

--- a/requester/print.go
+++ b/requester/print.go
@@ -62,10 +62,7 @@ type report struct {
 }
 
 func newReport(w io.Writer, results chan *result, output string, n int) *report {
-	cap := n
-	if n > maxRes {
-		cap = maxRes
-	}
+	cap := min(n, maxRes)
 	return &report{
 		output:         output,
 		results:        results,

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -123,7 +123,7 @@ func (b *Work) Run() {
 		runReporter(b.report)
 	}()
 	b.runWorkers()
-	b.Report()
+	b.Finish()
 }
 
 func (b *Work) Interrupt() {
@@ -134,7 +134,7 @@ func (b *Work) Interrupt() {
 	}
 }
 
-func (b *Work) Report() {
+func (b *Work) Finish() {
 	close(b.results)
 	total := time.Now().Sub(b.start)
 	// Wait until the reporter is done.

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -231,8 +231,6 @@ func (b *Work) runWorkers() {
 		MaxIdleConnsPerHost: min(b.C, maxIdleConn),
 		DisableCompression:  b.DisableCompression,
 		DisableKeepAlives:   b.DisableKeepAlives,
-		// TODO(jbd): Add dial timeout.
-		TLSHandshakeTimeout: time.Duration(b.Timeout) * time.Millisecond,
 		Proxy:               http.ProxyURL(b.ProxyAddr),
 	}
 	if b.H2 {


### PR DESCRIPTION
…ly update latency metrics, also only present histogram / latency values for a maximum number of values. Initialize latency lists with correct capacity.  Use a single transport object that is shared by all workers. Fix incorrect interrupt shutdown mechanism.

With this, hey will never use more than a certain amount of memory (on my tests, max ~120MB). This should fix issue #73 and issue #31

@rakyll  Could you review this PR?