### PR TITLE
change qps to limit total workers request rate (fix #72)

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -110,7 +110,6 @@ func main() {
 	runtime.GOMAXPROCS(*cpus)
 	num := *n
 	conc := *c
-	q := *q
 
 	if num <= 0 || conc <= 0 {
 		usageAndExit("-n and -c cannot be smaller than 1.")
@@ -119,6 +118,12 @@ func main() {
 	if num < conc {
 		usageAndExit("-n cannot be less than -c.")
 	}
+
+	if *q > 0 && *q < conc {
+		usageAndExit("-q cannot be less than -c.")
+	}
+
+	qps := *q / conc
 
 	url := flag.Args()[0]
 	method := strings.ToUpper(*m)
@@ -198,7 +203,7 @@ func main() {
 		RequestBody:        bodyAll,
 		N:                  num,
 		C:                  conc,
-		QPS:                q,
+		QPS:                qps,
 		Timeout:            *t,
 		DisableCompression: *disableCompression,
 		DisableKeepAlives:  *disableKeepAlives,

--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -63,8 +63,8 @@ func TestQps(t *testing.T) {
 	}
 	wg.Add(1)
 	time.AfterFunc(time.Second, func() {
-		if count > 1 {
-			t.Errorf("Expected to work 1 times, found %v", count)
+		if count != 2 {
+			t.Errorf("Expected to work 2 times, found %v", count)
 		}
 		wg.Done()
 	})


### PR DESCRIPTION
- Change the rate limit to global limit not per worker.
- Worker send new requests after a few microseconds instead of previous request is finished.