### PR TITLE
Generate test coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: go
 go:
   - 1.9
+
+script:
+  - ./test.sh
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![hey](http://i.imgur.com/szzD9q0.png)
 
 [![Build Status](https://travis-ci.org/rakyll/hey.svg?branch=master)](https://travis-ci.org/rakyll/hey)
+[![codecov](https://codecov.io/gh/rakyll/hey/branch/master/graph/badge.svg)](https://codecov.io/gh/rakyll/hey)
+[![GoDoc](https://godoc.org/github.com/rakyll/hey?status.svg)](https://godoc.org/github.com/rakyll/hey)
 
 hey is a tiny program that sends some load to a web application.
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.out
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -race -coverprofile=profile.out -covermode=atomic $d
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.out
+        rm profile.out
+    fi
+done


### PR DESCRIPTION
This is kind of a proposal actually. Running a mere coverage check on the main package, I found out it was pretty low and thought it'd be a good idea to have a coverage check run in the CI pipeline.

The script comes from [codecov/example-go](https://github.com/codecov/example-go), and the coverage badge in the readme will work as soon as the account on [codecov.io](https://codecov.io/) is ready.

Do you also think this make sense?