### PR TITLE
Reorganize the imports in hey.go to be more go-style compliant

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	gourl "net/url"
 	"os"
@@ -26,10 +27,9 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/rakyll/hey/requester"
-	"math"
-	"time"
 )
 
 const (


### PR DESCRIPTION
To be compliant, the order of the imports shall be standard first, then third party packages, then internal packages.