### PR TITLE
Added dynamic HTTP request body generation based on templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Options:
   -T  Content-type, defaults to "text/html".
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
+  -X  Dynamic HTTP request body generation from template.
+      For example, {{int}} will be replaced with an incrementing integer from 0 to n;
+      {{datetime}} with current RFC3339 time.
   -h2 Enable HTTP/2.
 
   -host	HTTP Host header.

--- a/hey.go
+++ b/hey.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rakyll/hey/requester"
+	"github.com/segmentio/hey/requester" // XXX
 )
 
 const (
@@ -59,6 +59,7 @@ var (
 	h2   = flag.Bool("h2", false, "")
 	cpus = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
 
+	enableRenderer     = flag.Bool("X", false, "")
 	disableCompression = flag.Bool("disable-compression", false, "")
 	disableKeepAlives  = flag.Bool("disable-keepalive", false, "")
 	disableRedirects   = flag.Bool("disable-redirects", false, "")
@@ -89,6 +90,9 @@ Options:
   -T  Content-type, defaults to "text/html".
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
+  -X  Dynamic HTTP request body generation from template.
+      For example, {{int}} will be replaced with an incrementing integer from 0 to n;
+      {{datetime}} with current RFC3339 time.
   -h2 Enable HTTP/2.
 
   -host	HTTP Host header.
@@ -197,7 +201,6 @@ func main() {
 	if err != nil {
 		usageAndExit(err.Error())
 	}
-	req.ContentLength = int64(len(bodyAll))
 
 	// set host header if set
 	if *hostHeader != "" {
@@ -224,6 +227,7 @@ func main() {
 		C:                  conc,
 		QPS:                q,
 		Timeout:            *t,
+		EnableRenderer:     *enableRenderer,
 		DisableCompression: *disableCompression,
 		DisableKeepAlives:  *disableKeepAlives,
 		DisableRedirects:   *disableRedirects,

--- a/hey.go
+++ b/hey.go
@@ -198,9 +198,6 @@ func main() {
 		usageAndExit(err.Error())
 	}
 	req.ContentLength = int64(len(bodyAll))
-	if username != "" || password != "" {
-		req.SetBasicAuth(username, password)
-	}
 
 	// set host header if set
 	if *hostHeader != "" {
@@ -215,6 +212,10 @@ func main() {
 	}
 	header.Set("User-Agent", ua)
 	req.Header = header
+
+	if username != "" || password != "" {
+		req.SetBasicAuth(username, password)
+	}
 
 	w := &requester.Work{
 		Request:            req,

--- a/requester/renderer.go
+++ b/requester/renderer.go
@@ -1,0 +1,40 @@
+package requester
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+type renderer struct {
+	results  chan []byte
+	handlers map[string]func(id int) string
+}
+
+func newRenderer(results chan []byte) *renderer {
+	return &renderer{
+		results: results,
+		handlers: map[string]func(int) string{
+			"int": func(i int) string {
+				return strconv.Itoa(i)
+			},
+			"datetime": func(i int) string {
+				return time.Now().Format(time.RFC3339Nano)
+			},
+		},
+	}
+}
+
+func runRenderer(r *renderer, template []byte, n int) {
+	for i := 0; i < n; i++ {
+		r.results <- r.Render(template, i)
+	}
+}
+
+func (r *renderer) Render(template []byte, i int) []byte {
+	body := string(template)
+	for key, generator := range r.handlers {
+		body = strings.Replace(body, "{{"+key+"}}", generator(i), -1)
+	}
+	return []byte(body)
+}

--- a/requester/renderer_test.go
+++ b/requester/renderer_test.go
@@ -1,0 +1,63 @@
+package requester
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRenderer(t *testing.T) {
+	var bitmap int32
+	var mux sync.Mutex
+	template := "{{int}} foo {{datetime}} bar {{int}}"
+	start := time.Now()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		words := strings.Fields(string(body))
+		if len(words) != 5 {
+			t.Errorf("Expected to have 5 words, found %d", len(words))
+		}
+		if words[0] != words[4] {
+			t.Errorf("Expected int to be the same, found %s %s", words[0], words[4])
+		}
+		if words[1]+words[3] != "foobar" {
+			t.Errorf("Expected to have foo bar, found %s %s", words[1], words[3])
+		}
+
+		mux.Lock()
+		defer mux.Unlock()
+
+		renderTime, _ := time.Parse(time.RFC3339Nano, words[2])
+		if renderTime.Before(start) || renderTime.After(time.Now()) {
+			t.Errorf("Expected time to be recent %v, found %s", start, words[2])
+		}
+
+		i, _ := strconv.Atoi(words[0])
+		if bitmap&(1<<uint(i)) != 0 {
+			t.Errorf("Expected to have foo bar, found %s %s", words[1], words[3])
+		}
+		bitmap |= (1 << uint(i))
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL, nil)
+	w := &Work{
+		Request:        req,
+		RequestBody:    []byte(template),
+		EnableRenderer: true,
+		N:              10,
+		C:              1,
+	}
+	w.Run()
+
+	if bitmap != (1<<uint(w.N))-1 {
+		t.Errorf("Expected %d bits, found %x", w.N, bitmap)
+	}
+}

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -67,6 +67,9 @@ type Work struct {
 	// Qps is the rate limit in queries per second.
 	QPS float64
 
+	// EnableRenderer is an option to enable template-based rendering of response
+	EnableRenderer bool
+
 	// DisableCompression is an option to disable compression in response
 	DisableCompression bool
 
@@ -87,9 +90,11 @@ type Work struct {
 	// Writer is where results will be written. If nil, results are written to stdout.
 	Writer io.Writer
 
-	results chan *result
-	stopCh  chan struct{}
-	start   time.Time
+	renderer   *renderer
+	rendererCh chan []byte
+	results    chan *result
+	stopCh     chan struct{}
+	start      time.Time
 
 	report *report
 }
@@ -112,6 +117,13 @@ func (b *Work) Run() {
 	go func() {
 		runReporter(b.report)
 	}()
+	if b.EnableRenderer {
+		b.rendererCh = make(chan []byte, 256)
+		b.renderer = newRenderer(b.rendererCh)
+		go func() {
+			runRenderer(b.renderer, b.RequestBody, b.N)
+		}()
+	}
 	b.runWorkers()
 	b.Finish()
 }
@@ -137,7 +149,12 @@ func (b *Work) makeRequest(c *http.Client) {
 	var code int
 	var dnsStart, connStart, resStart, reqStart, delayStart time.Time
 	var dnsDuration, connDuration, resDuration, reqDuration, delayDuration time.Duration
-	req := cloneRequest(b.Request, b.RequestBody)
+	body := b.RequestBody
+	if b.rendererCh != nil {
+		body = <-b.rendererCh
+	}
+
+	req := cloneRequest(b.Request, body)
 	trace := &httptrace.ClientTrace{
 		DNSStart: func(info httptrace.DNSStartInfo) {
 			dnsStart = time.Now()
@@ -256,6 +273,7 @@ func cloneRequest(r *http.Request, body []byte) *http.Request {
 	}
 	if len(body) > 0 {
 		r2.Body = ioutil.NopCloser(bytes.NewReader(body))
+		r2.ContentLength = int64(len(body))
 	}
 	return r2
 }


### PR DESCRIPTION
Hey "hey" maintainers,

I added template tags rendering to the tool for dynamic HTTP request body generation. Two tags are supported: {{int}} and {{datetime}}. When the tool is run with "-X" flag, it will replace the tags in the HTTP request body with dynamic contents, such as incrementing integer and RFC3339 time.

Would love to get your feedback! Thanks!