### PR TITLE
add flag `-version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+PROJ=hey
+VERSION?=$(shell ./scripts/git-version.sh)
+TIME=$(shell date "+%F_%T")
+
+LD_FLAGS="-w -X $(PROJ)/version.BuildName=$(PROJ) \
+			 -X $(PROJ)/version.BuildVersion=$(VERSION) \
+			 -X $(PROJ)/version.BuildTime=$(TIME) \
+			-linkmode external -extldflags '-static'"
+
+# create some temporary folder
+$(shell mkdir -p _output/bin)
+
+.PHONY: build
+build: clean
+	@echo start compiling
+	@CGO_ENABLED=0 go build -o _output/bin/$(PROJ) --ldflags $(LD_FLAGS) .
+	@echo complete the compilation
+
+.PHONY: clean
+clean:
+	@echo start cleaning
+	@rm -rf _output/bin
+	@echo complete the cleanup

--- a/hey.go
+++ b/hey.go
@@ -16,20 +16,20 @@
 package main
 
 import (
+	gourl "net/url"
+	"strings"
+	"hey/requester"
+	"hey/version"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
+	"runtime"
 	"math"
 	"net/http"
-	gourl "net/url"
-	"os"
+	"io/ioutil"
 	"os/signal"
-	"regexp"
-	"runtime"
-	"strings"
 	"time"
-
-	"github.com/rakyll/hey/requester"
+	"regexp"
 )
 
 const (
@@ -63,6 +63,8 @@ var (
 	disableKeepAlives  = flag.Bool("disable-keepalive", false, "")
 	disableRedirects   = flag.Bool("disable-redirects", false, "")
 	proxyAddr          = flag.String("x", "", "")
+
+	v = flag.Bool("version", false, "")
 )
 
 var usage = `Usage: hey [options...] <url>
@@ -99,6 +101,8 @@ Options:
   -disable-redirects    Disable following of HTTP redirects
   -cpus                 Number of used cpu cores.
                         (default for current machine is %d cores)
+
+  -version				display version information and exit.
 `
 
 func main() {
@@ -110,6 +114,16 @@ func main() {
 	flag.Var(&hs, "H", "")
 
 	flag.Parse()
+
+	if *v {
+		fmt.Printf("Project: %s\nVersion: %s\nBuildTime: %s\n",
+			version.BuildName,
+			version.BuildVersion,
+			version.BuildTime,
+		)
+		return
+	}
+
 	if flag.NArg() < 1 {
 		usageAndExit("")
 	}

--- a/scripts/git-version.sh
+++ b/scripts/git-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Since this script will be run in a rkt container, use "/bin/sh" instead of "/bin/bash"
+# parse the current git commit hash
+COMMIT=`git rev-parse HEAD`
+# check if the current commit has a matching tag
+TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)
+
+# use the matching tag as the version, if available
+if [ -z "$TAG" ]; then
+    VERSION=${COMMIT}
+else
+    VERSION=${TAG}
+fi
+
+# check for changed files (not untracked files)
+if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
+    VERSION="${VERSION}-dirty"
+fi
+
+echo ${VERSION}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,9 @@
+package version
+
+
+var (
+	BuildName string
+	BuildVersion string
+	BuildTime string
+)
+


### PR DESCRIPTION
hey is a compact HTTP benchmarking tool, we only use a binary file to generate significant load on the machine. The version of hey could not be viewed by cli. so I add the flag `-version`