### PR TITLE
Add note about option '-o' (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Options:
   -z  Duration of application to send requests. When duration is reached,
       application stops and exits. If duration is specified, n is ignored.
       Examples: -z 10s -z 3m.
-  -o  Output type. If none provided, a summary is printed.
+  -o  Output type. If none provided, a summary is printed out stdout
+      (you might have remembered file output, but stdout is only supported).
       "csv" is the only supported alternative. Dumps the response
       metrics in comma-separated values format.
 


### PR DESCRIPTION
#115
Many people might have been confused that “-o” option is file output. (e.g. curl, gcc)
so, I add the notation in README, it does not have function that output into a file.