### PR TITLE
Incorrect percentile calculation for low number of requests

### DIFF
--- a/requester/report_test.go
+++ b/requester/report_test.go
@@ -1,0 +1,39 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requester
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLatencies(t *testing.T) {
+	lats := make([]float64, 100)
+	for i := 0; i < len(lats); i++ {
+		lats[i] = float64(i + 1)
+	}
+	r := &report{lats: lats}
+	expected := make([]LatencyDistribution, len(pctls))
+	for i, pctl := range pctls {
+		expected[i] = LatencyDistribution{
+			Percentage: pctl,
+			Latency:    float64(pctl),
+		}
+	}
+	actual := r.latencies()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v, found %v", expected, actual)
+	}
+}


### PR DESCRIPTION
(I've been using hey quite a bit recently, to load-test my stuff. Thanks for writing and maintaining it!) 

I noticed something weird regarding the latency-distribution results: if I use a small enough value for the `n` flag, the higher percentiles (both percentage and latency) have value 0. Here is an example:

``` shell
$ hey -n 10 -c 2 https://somewebsite.com/

Latency distribution:
  10% in 0.2792 secs
  25% in 0.2954 secs
  50% in 0.3341 secs
  75% in 1.2886 secs
  90% in 1.3366 secs
  0% in 0.0000 secs
  0% in 0.0000 secs
```

I had a look at the `latencies` method, and its implementation confounds me... Which algorithm/formula does it correspond to?

How about using the [nearest-rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method) instead? I've modified `latencies` accordingly, and I get more sensical results, even in cases of low `n` values:

``` shell
$ hey -n 10 -c 2 https://somewebsite.com/

Latency distribution:
  10% in 0.3018 secs
  25% in 0.3577 secs
  50% in 0.4156 secs
  75% in 0.6103 secs
  90% in 0.9831 secs
  95% in 1.0380 secs
  99% in 1.0380 secs
```

Let me know what you think.