### PR TITLE
Rename "DNS-lookup" to "DNS lookup" (fixes #123)

### DIFF
--- a/requester/print.go
+++ b/requester/print.go
@@ -92,7 +92,7 @@ Latency distribution:{{ range .LatencyDistribution }}
 
 Details (average, fastest, slowest):
   DNS+dialup:	{{ formatNumber .AvgConn }} secs, {{ formatNumber .Fastest }} secs, {{ formatNumber .Slowest }} secs
-  DNS-lookup:	{{ formatNumber .AvgDNS }} secs, {{ formatNumber .DnsMax }} secs, {{ formatNumber .DnsMin }} secs
+  DNS lookup:	{{ formatNumber .AvgDNS }} secs, {{ formatNumber .DnsMax }} secs, {{ formatNumber .DnsMin }} secs
   req write:	{{ formatNumber .AvgReq }} secs, {{ formatNumber .ReqMax }} secs, {{ formatNumber .ReqMin }} secs
   resp wait:	{{ formatNumber .AvgDelay }} secs, {{ formatNumber .DelayMax }} secs, {{ formatNumber .DelayMin }} secs
   resp read:	{{ formatNumber .AvgRes }} secs, {{ formatNumber .ResMax }} secs, {{ formatNumber .ResMin }} secs


### PR DESCRIPTION
"DNS-lookup" could be interpreted as "DNS lookup duration minus some other lookup duration". This change removes the ambiguity.