### PR TITLE
Add request offset to csv

### DIFF
--- a/requester/print.go
+++ b/requester/print.go
@@ -12,6 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*
+Hey supports two output formats: summary and CSV
+
+The summary output presents a number of statistics about the requests in a
+human-readable format, including:
+- general statistics: requests/second, total runtime, and average, fastest, and slowest requests.
+- a response time histogram.
+- a percentile latency distribution.
+- statistics (average, fastest, slowest) on the stages of the requests.
+
+The comma-separated CSV format is proceeded by a header, and consists of the following columns:
+1. response-time:	Total time taken for request (in seconds)
+2. DNS+dialup:		Time taken to establish the TCP connection (in seconds)
+3. DNS:				Time taken to do the DNS lookup (in seconds)
+4. Request-write:	Time taken to write full request (in seconds)
+5. Response-delay: 	Time taken to first byte received (in seconds)
+6. Response-read:	Time taken to read full response (in seconds)
+7. status-code:		HTTP status code of the response (e.g. 200)
+8. offset:			The time since the start of the benchmark when the request was started. (in seconds)
+*/
 package requester
 
 import (

--- a/requester/print.go
+++ b/requester/print.go
@@ -103,7 +103,6 @@ Status code distribution:{{ range $code, $num := .StatusCodeDist }}
 {{ if gt (len .ErrorDist) 0 }}Error distribution:{{ range $err, $num := .ErrorDist }}
   [{{ $num }}]	{{ $err }}{{ end }}{{ end }}
 `
-	csvTmpl = `{{ $connLats := .ConnLats }}{{ $dnsLats := .DnsLats }}{{ $dnsLats := .DnsLats }}{{ $reqLats := .ReqLats }}{{ $delayLats := .DelayLats }}{{ $resLats := .ResLats }}{{ $statusCodeLats := .StatusCodes }}{{ $offsets := .Offsets}}
-response-time,DNS+dialup,DNS,Request-write,Response-delay,Response-read,status-code,offset{{ range $i, $v := .Lats }}
+	csvTmpl = `{{ $connLats := .ConnLats }}{{ $dnsLats := .DnsLats }}{{ $dnsLats := .DnsLats }}{{ $reqLats := .ReqLats }}{{ $delayLats := .DelayLats }}{{ $resLats := .ResLats }}{{ $statusCodeLats := .StatusCodes }}{{ $offsets := .Offsets}}response-time,DNS+dialup,DNS,Request-write,Response-delay,Response-read,status-code,offset{{ range $i, $v := .Lats }}
 {{ formatNumber $v }},{{ formatNumber (index $connLats $i) }},{{ formatNumber (index $dnsLats $i) }},{{ formatNumber (index $reqLats $i) }},{{ formatNumber (index $delayLats $i) }},{{ formatNumber (index $resLats $i) }},{{ formatNumberInt (index $statusCodeLats $i) }},{{ formatNumber (index $offsets $i) }}{{ end }}`
 )

--- a/requester/print.go
+++ b/requester/print.go
@@ -103,7 +103,7 @@ Status code distribution:{{ range $code, $num := .StatusCodeDist }}
 {{ if gt (len .ErrorDist) 0 }}Error distribution:{{ range $err, $num := .ErrorDist }}
   [{{ $num }}]	{{ $err }}{{ end }}{{ end }}
 `
-	csvTmpl = `{{ $connLats := .ConnLats }}{{ $dnsLats := .DnsLats }}{{ $dnsLats := .DnsLats }}{{ $reqLats := .ReqLats }}{{ $delayLats := .DelayLats }}{{ $resLats := .ResLats }}{{ $statusCodeLats := .StatusCodes }}
-response-time,DNS+dialup,DNS,Request-write,Response-delay,Response-read,status-code{{ range $i, $v := .Lats }}
-{{ formatNumber $v }},{{ formatNumber (index $connLats $i) }},{{ formatNumber (index $dnsLats $i) }},{{ formatNumber (index $reqLats $i) }},{{ formatNumber (index $delayLats $i) }},{{ formatNumber (index $resLats $i) }},{{ formatNumberInt (index $statusCodeLats $i) }}{{ end }}`
+	csvTmpl = `{{ $connLats := .ConnLats }}{{ $dnsLats := .DnsLats }}{{ $dnsLats := .DnsLats }}{{ $reqLats := .ReqLats }}{{ $delayLats := .DelayLats }}{{ $resLats := .ResLats }}{{ $statusCodeLats := .StatusCodes }}{{ $offsets := .Offsets}}
+response-time,DNS+dialup,DNS,Request-write,Response-delay,Response-read,status-code,offset{{ range $i, $v := .Lats }}
+{{ formatNumber $v }},{{ formatNumber (index $connLats $i) }},{{ formatNumber (index $dnsLats $i) }},{{ formatNumber (index $reqLats $i) }},{{ formatNumber (index $delayLats $i) }},{{ formatNumber (index $resLats $i) }},{{ formatNumberInt (index $statusCodeLats $i) }},{{ formatNumber (index $offsets $i) }}{{ end }}`
 )

--- a/requester/report.go
+++ b/requester/report.go
@@ -47,6 +47,7 @@ type report struct {
 	reqLats     []float64
 	resLats     []float64
 	delayLats   []float64
+	offsets     []float64
 	statusCodes []int
 
 	results chan *result
@@ -101,6 +102,7 @@ func runReporter(r *report) {
 				r.delayLats = append(r.delayLats, res.delayDuration.Seconds())
 				r.resLats = append(r.resLats, res.resDuration.Seconds())
 				r.statusCodes = append(r.statusCodes, res.statusCode)
+				r.offsets = append(r.offsets, res.offset.Seconds())
 			}
 			if res.contentLength > 0 {
 				r.sizeTotal += res.contentLength
@@ -158,6 +160,7 @@ func (r *report) snapshot() Report {
 		ReqLats:     make([]float64, len(r.lats)),
 		ResLats:     make([]float64, len(r.lats)),
 		DelayLats:   make([]float64, len(r.lats)),
+		Offsets:     make([]float64, len(r.lats)),
 		StatusCodes: make([]int, len(r.lats)),
 	}
 
@@ -174,6 +177,7 @@ func (r *report) snapshot() Report {
 	copy(snapshot.ResLats, r.resLats)
 	copy(snapshot.DelayLats, r.delayLats)
 	copy(snapshot.StatusCodes, r.statusCodes)
+	copy(snapshot.Offsets, r.offsets)
 
 	sort.Float64s(r.lats)
 	r.fastest = r.lats[0]
@@ -292,6 +296,7 @@ type Report struct {
 	ReqLats     []float64
 	ResLats     []float64
 	DelayLats   []float64
+	Offsets     []float64
 	StatusCodes []int
 
 	Total time.Duration

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -37,6 +37,7 @@ const maxIdleConn = 500
 type result struct {
 	err           error
 	statusCode    int
+	offset        time.Duration
 	duration      time.Duration
 	connDuration  time.Duration // connection setup(DNS lookup + Dial up) duration
 	dnsDuration   time.Duration // dns lookup duration
@@ -183,6 +184,7 @@ func (b *Work) makeRequest(c *http.Client) {
 	resDuration = t - resStart
 	finish := t - s
 	b.results <- &result{
+		offset:        s,
 		statusCode:    code,
 		duration:      finish,
 		err:           err,


### PR DESCRIPTION
This change ensures that the offset of each request is stored (and printed when using csv) to allow users to visualize and analyze temporal relationships between requests.

As a flyby this change fixes a minor bug where the CSV output starts with an empty line.