### PR TITLE
Fix go-vet gripes in requester test

### DIFF
--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -73,10 +73,9 @@ func TestQps(t *testing.T) {
 }
 
 func TestRequest(t *testing.T) {
-	var uri, contentType, some, method, auth string
+	var uri, contentType, some, auth string
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		uri = r.RequestURI
-		method = r.Method
 		contentType = r.Header.Get("Content-type")
 		some = r.Header.Get("X-some")
 		auth = r.Header.Get("Authorization")


### PR DESCRIPTION
Running `go vet` for the `requester` package reveals that a variable is unused in method `TestRequest`:

```sh
$ cd requester/
$ go vet
# github.com/rakyll/hey/requester
./requester_test.go:76:30: method declared but not used
vet: typecheck failures
$
```

I've removed the variable accordingly, which pacified `go vet`:

```sh
$ go vet
$
```

