### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: hey
+version: '1.0'
+summary: HTTP load generator, ApacheBench (ab) replacement
+description: |
+  HTTP load generator, ApacheBench (ab) replacement.
+grade: stable
+confinement: strict
+base: core18
+parts:
+  hey:
+    plugin: go
+    source: https://github.com/rakyll/hey.git
+    go-importpath: github.com/rakyll/hey
+    build-packages:
+      - build-essential
+apps:
+  hey:
+    command: bin/hey
+    plugs:
+      - home


### PR DESCRIPTION
Hey.

See what I did there :)

On a more serious note, I'd like to ask you to build hey as a snap package and publish it in the Snap Store.

TL;DR:

Snaps are cross-distro Linux software packages, supported on Ubuntu, Debian, Manjaro, Fedora, OpenSUSE, and many others distributions. Snaps are featured in the Snap Store (snapcraft.io/store), with an audience of millions. They also have automatic updates, so you can always make sure your users run the latest version benchmarks.

Snaps can be built locally using the snapcraft cli tool, build/CI systems or via our free build.snapcraft.io service.

If you accept this PR, here's the sequence of steps needed to build the hey snap locally (using snapcraft cli tool).

1. Install snapcraft and checkout

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/hey.git
cd hey
git checkout add-snapcraft
snapcraft

This command creates a <hey-version>.snap file from snapcraft.yaml (which contains build instructions), something like hey_1.0_amd64.snap.

2. Test the snap.

snap install hey_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the snap isn't signed just yet.

Once installed, the hey command can be executed, e.g.: snap run hey <benchmark options>

3. Register a developer account in the snap store https://snapcraft.io/account.

4. Register the hey name in the store. 

snapcraft login
snapcraft register

5. Upload a built snap to the store.

snapcraft push hey_1.0_amd64.snap --release edge

We use risk levels called channels for different builds. Edge is typically used to host the latest build from git master. Stable is where stable releases are pushed. Optionally, beta and candidate channels can also be used, for different levels of stability and testing.

4. Install from store & test.

You can do this on a clean machine.

snap install hey --edge

Anyway, we can help there, and we'd be glad to feature your application in our store.