### PR TITLE
Add a Work.Report() method to get the Report object

### DIFF
--- a/requester/requester.go
+++ b/requester/requester.go
@@ -140,6 +140,11 @@ func (b *Work) Finish() {
 	b.report.finalize(total)
 }
 
+// Report returns a snapshot of the report
+func (b *Work) Report() Report {
+	return b.report.snapshot()
+}
+
 func (b *Work) makeRequest(c *http.Client) {
 	s := now()
 	var size int64


### PR DESCRIPTION
This just adds a public Report() method to expose the Report object programmatically instead of parsing the printed output.