### PR TITLE
Add Work.RequestFunc

### DIFF
--- a/requester/requester.go
+++ b/requester/requester.go
@@ -53,6 +53,10 @@ type Work struct {
 
 	RequestBody []byte
 
+	// RequestFunc is a function to generate requests. If it is nil, then
+	// Request and RequestData are cloned for each request.
+	RequestFunc func() *http.Request
+
 	// N is the total number of requests to make.
 	N int
 
@@ -146,7 +150,12 @@ func (b *Work) makeRequest(c *http.Client) {
 	var code int
 	var dnsStart, connStart, resStart, reqStart, delayStart time.Duration
 	var dnsDuration, connDuration, resDuration, reqDuration, delayDuration time.Duration
-	req := cloneRequest(b.Request, b.RequestBody)
+	var req *http.Request
+	if b.RequestFunc != nil {
+		req = b.RequestFunc()
+	} else {
+		req = cloneRequest(b.Request, b.RequestBody)
+	}
 	trace := &httptrace.ClientTrace{
 		DNSStart: func(info httptrace.DNSStartInfo) {
 			dnsStart = now()

--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -73,10 +73,9 @@ func TestQps(t *testing.T) {
 }
 
 func TestRequest(t *testing.T) {
-	var uri, contentType, some, method, auth string
+	var uri, contentType, some, auth string
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		uri = r.RequestURI
-		method = r.Method
 		contentType = r.Header.Get("Content-type")
 		some = r.Header.Get("X-some")
 		auth = r.Header.Get("Authorization")


### PR DESCRIPTION
With this commit, people using hey as a library can generate different requests, rather than repeating the same request each time. This can be useful for simulating a variety of requests or replaying traffic.