### PR TITLE
Increase buffer and maximum report size

### DIFF
--- a/requester/report.go
+++ b/requester/report.go
@@ -28,7 +28,7 @@ const (
 )
 
 // We report for max 1M results.
-const maxRes = 1000000
+const maxRes = 2147483647
 
 type report struct {
 	avgTotal float64

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Max size of the buffer of result channel.
-const maxResult = 1000000
+const maxResult = 2147483647
 const maxIdleConn = 500
 
 type result struct {


### PR DESCRIPTION
Very useful when running relatively long benchmarks on fast servers