### PR TITLE
Support mTLS client certificate.

### DIFF
--- a/requester/requester.go
+++ b/requester/requester.go
@@ -85,6 +85,9 @@ type Work struct {
 	// Optional.
 	ProxyAddr *url.URL
 
+	// Optional set of client certificates to use for mTLS:
+	Certs []tls.Certificate
+
 	// Writer is where results will be written. If nil, results are written to stdout.
 	Writer io.Writer
 
@@ -230,6 +233,7 @@ func (b *Work) runWorkers() {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 			ServerName:         b.Request.Host,
+			Certificates:       b.Certs,
 		},
 		MaxIdleConnsPerHost: min(b.C, maxIdleConn),
 		DisableCompression:  b.DisableCompression,


### PR DESCRIPTION
Add flags `-cert` and `-key` to specify client certificates.