### PR TITLE
Drop duplicated (*Work).Init from main()

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -226,7 +226,6 @@ func main() {
 		ProxyAddr:          proxyURL,
 		Output:             *output,
 	}
-	w.Init()
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)


### PR DESCRIPTION
because it is called from (*Work).Run:

https://github.com/rakyll/hey/blob/22735a3bf7611499f341de944151d22fac68665c/requester/requester.go#L117

---

could you review it?