### PR TITLE
Add support for request URL randomization / shuffling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/rakyll/hey
 
 require (
+	github.com/lucasjones/reggen v0.0.0-20180717132126-cdb49ff09d77
 	golang.org/x/net v0.0.0-20181017193950-04a2e542c03f
 	golang.org/x/text v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/lucasjones/reggen v0.0.0-20180717132126-cdb49ff09d77 h1:6xiz3+ZczT3M4+I+JLpcPGG1bQKm8067HktB17EDWEE=
+github.com/lucasjones/reggen v0.0.0-20180717132126-cdb49ff09d77/go.mod h1:5ELEyG+X8f+meRWHuqUOewBOhvHkl7M76pdGEansxW4=
 golang.org/x/net v0.0.0-20181017193950-04a2e542c03f h1:4pRM7zYwpBjCnfA1jRmhItLxYJkaEnsmuAcRtA347DA=
 golang.org/x/net v0.0.0-20181017193950-04a2e542c03f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/request/shuffler.go
+++ b/request/shuffler.go
@@ -43,6 +43,8 @@ func newShuffler(baseRequest *http.Request, genFunc func(match string) generator
 }
 
 func (s *Shuffler) Shuffle(r *http.Request) {
+	// NOTE: In a future revision, the parameter won't be needed.
+	// This change requires the extraction of a local Request type and wrapping http.Request with it.
 	for match, gen := range s.generatorMap {
 		r.URL, _ = r.URL.Parse(strings.Replace(r.URL.Path, match, gen.Generate(1), -1))
 	}

--- a/request/shuffler.go
+++ b/request/shuffler.go
@@ -1,0 +1,49 @@
+package request
+
+import (
+	"github.com/lucasjones/reggen"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+var /* const */ variablePattern = regexp.MustCompile("{{.*}}")
+
+type generator interface {
+	Generate(limit int) string
+}
+
+type Shuffler struct {
+	generatorMap map[string]generator
+}
+
+func NewShuffler(baseRequest *http.Request) *Shuffler {
+	return newShuffler(baseRequest, func(match string) generator {
+		gen, err := reggen.NewGenerator(match)
+		if err != nil {
+			log.Panicf("Invalid RegeExp: %s", match)
+		}
+		return gen
+	})
+}
+
+func newShuffler(baseRequest *http.Request, genFunc func(match string) generator) *Shuffler {
+	shuffler := &Shuffler{}
+	shuffler.generatorMap = make(map[string]generator)
+	for _, outerMatch := range variablePattern.FindStringSubmatch(baseRequest.URL.Path) {
+		innerMatch := strings.Replace(outerMatch, "{{", "", 1)
+		innerMatch = strings.Replace(innerMatch, "}}", "", 1)
+		if innerMatch != "" {
+			shuffler.generatorMap[outerMatch] = genFunc(outerMatch)
+		}
+	}
+
+	return shuffler
+}
+
+func (s *Shuffler) Shuffle(r *http.Request) {
+	for match, gen := range s.generatorMap {
+		r.URL, _ = r.URL.Parse(strings.Replace(r.URL.Path, match, gen.Generate(1), -1))
+	}
+}

--- a/request/shuffler_test.go
+++ b/request/shuffler_test.go
@@ -1,0 +1,26 @@
+package request
+
+import (
+	"net/http"
+	"testing"
+)
+
+type testGenerator struct{}
+
+func (t *testGenerator) Generate(limit int) string {
+	return "1234"
+}
+
+func Test_newShuffler(t *testing.T) {
+	r, _ := http.NewRequest("GET", "https://test.com/{{some_regex_pattern_here}}", nil)
+	s := newShuffler(r, func(match string) generator {
+		return &testGenerator{}
+	})
+
+	s.Shuffle(r)
+
+	expectedURL := "https://test.com/1234"
+	if r.URL.String() != expectedURL {
+		t.Errorf("Generated request URL does not match: %s, expected: %s", r.URL, expectedURL)
+	}
+}

--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -105,6 +105,9 @@ func TestRequest(t *testing.T) {
 	if some != "value" {
 		t.Errorf("X-some header is expected to be value, %v is found", some)
 	}
+	if method != "GET" {
+		t.Errorf("HTTP method is expected to be /, %v is found", method)
+	}
 	if auth != "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" {
 		t.Errorf("Basic authorization is not properly set")
 	}


### PR DESCRIPTION
As requested in #35, the idea is to use regular expressions in various places, which will lead to different URLs being used when requests are spawned.

This current implementation only works with RegEx passed directly as part of the URL path or its parameters:

```
hey https://google.com/"{{[a-z]{10}}}"
```

Depending on your shell, the wrapping parentheses might or might not be needed.

Although this part can be merged, this is an ongoing effort and further changes would require the introduction of a local `Request` type first.