### PR TITLE
Clarify -c and -q flag description

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -69,7 +69,7 @@ var usage = `Usage: hey [options...] <url>
 
 Options:
   -n  Number of requests to run. Default is 200.
-  -c  Number of requests to run concurrently. Total number of requests cannot
+  -c  Number of workers to run concurrently. Total number of requests cannot
       be smaller than the concurrency level. Default is 50.
   -q  Rate limit, in queries per second (QPS). Default is no rate limit.
   -z  Duration of application to send requests. When duration is reached,

--- a/hey.go
+++ b/hey.go
@@ -71,7 +71,7 @@ Options:
   -n  Number of requests to run. Default is 200.
   -c  Number of workers to run concurrently. Total number of requests cannot
       be smaller than the concurrency level. Default is 50.
-  -q  Rate limit, in queries per second (QPS). Default is no rate limit.
+  -q  Rate limit, in queries per second (QPS) per worker. Default is no rate limit.
   -z  Duration of application to send requests. When duration is reached,
       application stops and exits. If duration is specified, n is ignored.
       Examples: -z 10s -z 3m.


### PR DESCRIPTION
Changing the description of -c to `Number of workers to run concurrently...` and -q to `in queries per worker per second....`. This will clarify that the c flag is used to define the number of threads and -q is actually the number of requests per worker per second.

Motivated by #140 #143 and #158 

Use Cases:
- Someone who uses the duration (-z) flag, and want to set the total number of queries per second:
   * Recognize that QPS (queries per second) is `-c` times `-q`
- Someone who wants to send 2,000 total number of queries without changing `-n`:
   * Recognize that `-c` is not the total number of requests and would set `-c` as 10 because the default `-n` is 200 so `200 * 10 = 2,000 queries`

This makes more sense as a first impression, but I'm open to any recommendations!