### PR TITLE
Validate URL and protocol scheme. 

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -135,6 +135,14 @@ func main() {
 		}
 	}
 
+	parsedUrl, err := gourl.Parse(flag.Args()[0])
+	if err != nil {
+		usageAndExit(err.Error())
+	}
+	scheme := strings.ToLower(parsedUrl.Scheme)
+	if scheme == "" || scheme != "http" || scheme != "https" {
+		usageAndExit("unsupported protocol scheme - supported schemes: http(s)")
+	}
 	url := flag.Args()[0]
 	method := strings.ToUpper(*m)
 

--- a/requester/report.go
+++ b/requester/report.go
@@ -64,20 +64,20 @@ type report struct {
 }
 
 func newReport(w io.Writer, results chan *result, output string, n int) *report {
-	cap := min(n, maxRes)
+	capacity := min(n, maxRes)
 	return &report{
 		output:      output,
 		results:     results,
 		done:        make(chan bool, 1),
 		errorDist:   make(map[string]int),
 		w:           w,
-		connLats:    make([]float64, 0, cap),
-		dnsLats:     make([]float64, 0, cap),
-		reqLats:     make([]float64, 0, cap),
-		resLats:     make([]float64, 0, cap),
-		delayLats:   make([]float64, 0, cap),
-		lats:        make([]float64, 0, cap),
-		statusCodes: make([]int, 0, cap),
+		connLats:    make([]float64, 0, capacity),
+		dnsLats:     make([]float64, 0, capacity),
+		reqLats:     make([]float64, 0, capacity),
+		resLats:     make([]float64, 0, capacity),
+		delayLats:   make([]float64, 0, capacity),
+		lats:        make([]float64, 0, capacity),
+		statusCodes: make([]int, 0, capacity),
 	}
 }
 


### PR DESCRIPTION
Trying with `google.com` generates the following report:
```

Summary:
  Total:	0.0013 secs
  Slowest:	0.0000 secs
  Fastest:	0.0000 secs
  Average:	 NaN secs
  Requests/sec:	155560.3088
  

Response time histogram:


Latency distribution:

Details (average, fastest, slowest):
  DNS+dialup:	 NaN secs, 0.0000 secs, 0.0000 secs
  DNS-lookup:	 NaN secs, 0.0000 secs, 0.0000 secs
  req write:	 NaN secs, 0.0000 secs, 0.0000 secs
  resp wait:	 NaN secs, 0.0000 secs, 0.0000 secs
  resp read:	 NaN secs, 0.0000 secs, 0.0000 secs

Status code distribution:

Error distribution:
  [200]	Get google.com: unsupported protocol scheme ""
```

Similar reports are generated for invalid URLs `httpa://google.com`.

This PR fixes NaNs in the reports. 

Renamed `cap` to `capacity`. `cap` collides with the built-in `cap` function. 