### PR TITLE
Add optional TLS session resumption

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -59,6 +59,8 @@ var (
 	h2   = flag.Bool("h2", false, "")
 	cpus = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
 
+	tlsResume = flag.Bool("tls-session-resume", false, "")
+
 	disableCompression = flag.Bool("disable-compression", false, "")
 	disableKeepAlives  = flag.Bool("disable-keepalive", false, "")
 	disableRedirects   = flag.Bool("disable-redirects", false, "")
@@ -90,6 +92,8 @@ Options:
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
   -h2 Enable HTTP/2.
+
+  -tls-session-resume Enable TLS session resumption.
 
   -host	HTTP Host header.
 
@@ -223,6 +227,7 @@ func main() {
 		DisableKeepAlives:  *disableKeepAlives,
 		DisableRedirects:   *disableRedirects,
 		H2:                 *h2,
+		TLSResume:          *tlsResume,
 		ProxyAddr:          proxyURL,
 		Output:             *output,
 	}

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -62,6 +62,9 @@ type Work struct {
 	// H2 is an option to make HTTP/2 requests
 	H2 bool
 
+	// TLSResume is used to decide whether TLS session resumption is enabled between requests
+	TLSResume bool
+
 	// Timeout in seconds.
 	Timeout int
 
@@ -226,10 +229,17 @@ func (b *Work) runWorkers() {
 	var wg sync.WaitGroup
 	wg.Add(b.C)
 
+	var tlsCache tls.ClientSessionCache
+
+	if b.TLSResume {
+		tlsCache = tls.NewLRUClientSessionCache(1) // we only have one target
+	}
+
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 			ServerName:         b.Request.Host,
+			ClientSessionCache: tlsCache,
 		},
 		MaxIdleConnsPerHost: min(b.C, maxIdleConn),
 		DisableCompression:  b.DisableCompression,

--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -99,6 +99,9 @@ func TestRequest(t *testing.T) {
 	if uri != "/" {
 		t.Errorf("Uri is expected to be /, %v is found", uri)
 	}
+	if method != "GET" {
+		t.Errorf("Method is expected to be GET, got %v", method)
+	}
 	if contentType != "text/html" {
 		t.Errorf("Content type is expected to be text/html, %v is found", contentType)
 	}


### PR DESCRIPTION
This small PR fixes #198 

The flag name is obviously up for bikeshedding! :wink:

I also took the liberty of adding a very small missing test, which is unrelated to the PR, but was throwing a `vet` error. 