### PR TITLE
Generate random values in header and body of request

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Options:
   -disable-redirects    Disable following of HTTP redirects
   -cpus                 Number of used cpu cores.
                         (default for current machine is 8 cores)
+
+  -enable-tmpl  Header or body may include templates for random requests.
+                Allowed {{.Email}}, {{.RequestID}}, {{.Time}}, {{.DtTm}},
+                {{.Date}}, {{.Integer}}, {{.Float}}, {{.String}}.
+                May be used multiple times in header or body.
+                Ex1: -H 'x-request-id: {{.RequestID}}'
+                Ex2: -d '{ "user_email": "{{.Email}}", "user_login": "{{.String}}" }'
+                Ex3: -d '{ "primary_email": "{{.Email_1}}", "secondary_email": "{{.Email_2}}" }'
 ```
 
 Previously known as [github.com/rakyll/boom](https://github.com/rakyll/boom).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Options:
   -cpus                 Number of used cpu cores.
                         (default for current machine is 8 cores)
 
-  -enable-tmpl  Header or body may include templates for generating random requests.
+  -enable-tmpl  Header or body may include templates for generating request
+                with random values.
                 Allowed {{.Email}}, {{.RequestID}}, {{.Time}}, {{.DtTm}},
                 {{.Date}}, {{.Integer}}, {{.Float}}, {{.String}}.
                 May be used multiple times in header or body.

--- a/README.md
+++ b/README.md
@@ -62,13 +62,16 @@ Options:
   -cpus                 Number of used cpu cores.
                         (default for current machine is 8 cores)
 
-  -enable-tmpl  Header or body may include templates for random requests.
+  -enable-tmpl  Header or body may include templates for generating random requests.
                 Allowed {{.Email}}, {{.RequestID}}, {{.Time}}, {{.DtTm}},
                 {{.Date}}, {{.Integer}}, {{.Float}}, {{.String}}.
                 May be used multiple times in header or body.
                 Ex1: -H 'x-request-id: {{.RequestID}}'
+                reived x-request-id: 920bdca1fd9546f49cf4d9a0d1117cc8
                 Ex2: -d '{ "user_email": "{{.Email}}", "user_login": "{{.String}}" }'
+                recived { "user_email": " tghr94rql8@i3pj3.com", "user_login": "ee2r2s8qpt" }
                 Ex3: -d '{ "primary_email": "{{.Email_1}}", "secondary_email": "{{.Email_2}}" }'
+                recived { "primary_email": "8l928nbeiu@zhdpp.com", "secondary_email": "all01bcj4l@3s330.com" }
 ```
 
 Previously known as [github.com/rakyll/boom](https://github.com/rakyll/boom).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/rakyll/hey
 
 require (
+	github.com/google/uuid v1.1.1
 	golang.org/x/net v0.0.0-20181017193950-04a2e542c03f
 	golang.org/x/text v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/net v0.0.0-20181017193950-04a2e542c03f h1:4pRM7zYwpBjCnfA1jRmhItLxYJkaEnsmuAcRtA347DA=
 golang.org/x/net v0.0.0-20181017193950-04a2e542c03f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/hey.go
+++ b/hey.go
@@ -102,7 +102,8 @@ Options:
   -cpus                 Number of used cpu cores.
                         (default for current machine is %d cores)
 
-  -enable-tmpl  Header or body may include templates for generating random requests.
+  -enable-tmpl  Header or body may include templates for generating request 
+                with random values.
                 Allowed {{.Email}}, {{.RequestID}}, {{.Time}}, {{.DtTm}},
                 {{.Date}}, {{.Integer}}, {{.Float}}, {{.String}}.
                 May be used multiple times in header or body.

--- a/hey.go
+++ b/hey.go
@@ -63,6 +63,8 @@ var (
 	disableKeepAlives  = flag.Bool("disable-keepalive", false, "")
 	disableRedirects   = flag.Bool("disable-redirects", false, "")
 	proxyAddr          = flag.String("x", "", "")
+
+	enableTemplates = flag.Bool("enable-tmpl", false, "")
 )
 
 var usage = `Usage: hey [options...] <url>
@@ -99,6 +101,14 @@ Options:
   -disable-redirects    Disable following of HTTP redirects
   -cpus                 Number of used cpu cores.
                         (default for current machine is %d cores)
+
+  -enable-tmpl  Header or body may include templates for random requests.
+                Allowed {{.Email}}, {{.RequestID}}, {{.Time}}, {{.DtTm}},
+                {{.Date}}, {{.Integer}}, {{.Float}}, {{.String}}.
+                May be used multiple times in header or body.
+                Ex1: -H 'x-request-id: {{.RequestID}}'
+                Ex2: -d '{ "user_email": "{{.Email}}", "user_login": "{{.String}}" }'
+                Ex3: -d '{ "primary_email": "{{.Email_1}}", "secondary_email": "{{.Email_2}}" }'
 `
 
 func main() {
@@ -225,6 +235,7 @@ func main() {
 		H2:                 *h2,
 		ProxyAddr:          proxyURL,
 		Output:             *output,
+		EnableTemplates:    *enableTemplates,
 	}
 	w.Init()
 

--- a/hey.go
+++ b/hey.go
@@ -102,13 +102,16 @@ Options:
   -cpus                 Number of used cpu cores.
                         (default for current machine is %d cores)
 
-  -enable-tmpl  Header or body may include templates for random requests.
+  -enable-tmpl  Header or body may include templates for generating random requests.
                 Allowed {{.Email}}, {{.RequestID}}, {{.Time}}, {{.DtTm}},
                 {{.Date}}, {{.Integer}}, {{.Float}}, {{.String}}.
                 May be used multiple times in header or body.
                 Ex1: -H 'x-request-id: {{.RequestID}}'
+                reived x-request-id: 920bdca1fd9546f49cf4d9a0d1117cc8
                 Ex2: -d '{ "user_email": "{{.Email}}", "user_login": "{{.String}}" }'
+                recived { "user_email": " tghr94rql8@i3pj3.com", "user_login": "ee2r2s8qpt" }
                 Ex3: -d '{ "primary_email": "{{.Email_1}}", "secondary_email": "{{.Email_2}}" }'
+                recived { "primary_email": "8l928nbeiu@zhdpp.com", "secondary_email": "all01bcj4l@3s330.com" }
 `
 
 func main() {

--- a/tmpl/rand.go
+++ b/tmpl/rand.go
@@ -13,7 +13,7 @@ const (
 	maxLengthEmailUserName = 10
 	maxLengthEmailDomain   = 5
 
-	maxlengthString = 10
+	maxLengthString = 10
 
 	letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
 )
@@ -32,7 +32,7 @@ func RandomEmail() string {
 }
 
 func RandomString() string {
-	return randStringBytes(maxlengthString)
+	return randStringBytes(maxLengthString)
 }
 
 func RandomTime() string {

--- a/tmpl/rand.go
+++ b/tmpl/rand.go
@@ -1,0 +1,68 @@
+package tmpl
+
+import (
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	maxLengthEmailUserName = 10
+	maxLengthEmailDomain   = 5
+
+	maxlengthString = 10
+
+	letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
+)
+
+func randStringBytes(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func RandomEmail() string {
+	return randStringBytes(maxLengthEmailUserName) + "@" + randStringBytes(maxLengthEmailDomain) + ".com"
+}
+
+func RandomString() string {
+	return randStringBytes(maxlengthString)
+}
+
+func RandomTime() string {
+	randTime := time.Duration(rand.Int31n(86400)) * time.Second
+	return time.Now().UTC().Add(randTime).Format("15:04:05.000000")
+}
+
+func RandomDate() string {
+	randDate := time.Duration(rand.Int31n(365)) * time.Hour * 24
+	return time.Now().UTC().Add(randDate).Format("2006-01-02")
+}
+
+func RandomDateTime() string {
+	randTime := time.Duration(rand.Int31n(86400)) * time.Second
+	randDate := time.Duration(rand.Int31n(365)) * time.Hour * 24
+	return time.Now().UTC().Add(randTime).Add(randDate).Format("2006-01-02 15:04:05.000000")
+}
+
+func RandomInteger() string {
+	return strconv.Itoa(int(rand.Int63()))
+}
+
+func RandomFloat() string {
+	return strconv.FormatFloat(rand.Float64(), 'f', 10, 64)
+}
+
+func RandomRequest() string {
+	newUUID, err := uuid.NewRandom()
+	if err != nil {
+		return ""
+	}
+	return strings.ReplaceAll(newUUID.String(), "-", "")
+}

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -50,7 +50,7 @@ func (tmplItem TemplateItem) String() string {
 	return ""
 }
 
-// Generate randdov value based on tipe TemplateItem
+// Generate random value based on type TemplateItem
 func (tmplItem TemplateItem) Generate() string {
 	switch tmplItem {
 	case RequestID:
@@ -74,24 +74,24 @@ func (tmplItem TemplateItem) Generate() string {
 	return ""
 }
 
-// Convernt node form template to TemplateItem
-func nodeToTemplateItem(node string) TemplateItem {
+// Convert field to TemplateItem
+func fieldToTemplateItem(field string) TemplateItem {
 	switch {
-	case strings.Contains(node, RequestID.String()):
+	case strings.Contains(field, RequestID.String()):
 		return RequestID
-	case strings.Contains(node, Email.String()):
+	case strings.Contains(field, Email.String()):
 		return Email
-	case strings.Contains(node, Integer.String()):
+	case strings.Contains(field, Integer.String()):
 		return Integer
-	case strings.Contains(node, Date.String()):
+	case strings.Contains(field, Date.String()):
 		return Date
-	case strings.Contains(node, Time.String()):
+	case strings.Contains(field, Time.String()):
 		return Time
-	case strings.Contains(node, DateTime.String()):
+	case strings.Contains(field, DateTime.String()):
 		return DateTime
-	case strings.Contains(node, Float.String()):
+	case strings.Contains(field, Float.String()):
 		return Float
-	case strings.Contains(node, String.String()):
+	case strings.Contains(field, String.String()):
 		return String
 	}
 
@@ -126,8 +126,8 @@ func templateString(value string) (*template.Template, error) {
 	}
 
 	i := 0
-	for _, node := range ListTemplFields(tmpl) {
-		if nodeToTemplateItem(node) == Unknown {
+	for _, field := range ListTemplFields(tmpl) {
+		if fieldToTemplateItem(field) == Unknown {
 			i++
 		}
 	}
@@ -173,7 +173,7 @@ func Validate(req *http.Request, body []byte) error {
 func fillTemplate(tmpl *template.Template) (string, error) {
 	tmplItems := make(map[string]string)
 	for _, node := range ListTemplFields(tmpl) {
-		tmplItem := nodeToTemplateItem(node)
+		tmplItem := fieldToTemplateItem(node)
 		if tmplItem == Unknown {
 			continue
 		}

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -1,0 +1,229 @@
+package tmpl
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"text/template"
+	"text/template/parse"
+)
+
+type TemplateItem int
+
+const (
+	Unknown TemplateItem = iota
+	RequestID
+	Email
+	Date
+	Time
+	DateTime
+	Integer
+	Float
+	String
+)
+
+var (
+	ErrNoTmpl       = errors.New("no templates in request")
+	ErrUnknownsTmpl = errors.New("unknowns templates in request")
+)
+
+var stringToTemplateItem = map[string]TemplateItem{
+	"RequestID": RequestID, // Random requestID
+	"Email":     Email,     // Random email
+	"Date":      Date,      // Random date
+	"Time":      Time,      // Random time
+	"DtTm":      DateTime,  // Date and Time
+	"Integer":   Integer,   // Random integer value
+	"Float":     Float,     // Random float value
+	"String":    String,    // Random string
+}
+
+func (tmplItem TemplateItem) String() string {
+	for key, item := range stringToTemplateItem {
+		if item == tmplItem {
+			return key
+		}
+	}
+
+	return ""
+}
+
+// Generate randdov value based on tipe TemplateItem
+func (tmplItem TemplateItem) Generate() string {
+	switch tmplItem {
+	case RequestID:
+		return RandomRequest()
+	case Email:
+		return RandomEmail()
+	case String:
+		return RandomString()
+	case Time:
+		return RandomTime()
+	case Date:
+		return RandomDate()
+	case DateTime:
+		return RandomDateTime()
+	case Integer:
+		return RandomInteger()
+	case Float:
+		return RandomFloat()
+	}
+
+	return ""
+}
+
+// Convernt node form template to TemplateItem
+func nodeToTemplateItem(node string) TemplateItem {
+	switch {
+	case strings.Contains(node, RequestID.String()):
+		return RequestID
+	case strings.Contains(node, Email.String()):
+		return Email
+	case strings.Contains(node, Integer.String()):
+		return Integer
+	case strings.Contains(node, Date.String()):
+		return Date
+	case strings.Contains(node, Time.String()):
+		return Time
+	case strings.Contains(node, DateTime.String()):
+		return DateTime
+	case strings.Contains(node, Float.String()):
+		return Float
+	case strings.Contains(node, String.String()):
+		return String
+	}
+
+	return Unknown
+}
+
+func ListTemplFields(t *template.Template) []string {
+	return listNodeFields(t.Tree.Root, nil)
+}
+
+func listNodeFields(node parse.Node, res []string) []string {
+	if node.Type() == parse.NodeAction {
+		res = append(res, node.String())
+	}
+
+	if ln, ok := node.(*parse.ListNode); ok {
+		for _, n := range ln.Nodes {
+			res = listNodeFields(n, res)
+		}
+	}
+	return res
+}
+
+// Build template from string
+func templateString(value string) (*template.Template, error) {
+	if !(strings.Contains(value, "{{.") && strings.Contains(value, "}}")) {
+		return nil, ErrNoTmpl
+	}
+	tmpl, err := template.New("").Parse(value)
+	if err != nil {
+		return nil, ErrNoTmpl
+	}
+
+	i := 0
+	for _, node := range ListTemplFields(tmpl) {
+		if nodeToTemplateItem(node) == Unknown {
+			i++
+		}
+	}
+
+	if i > 0 {
+		return nil, ErrUnknownsTmpl
+	}
+
+	return tmpl, nil
+}
+
+// Build template from []byte value
+func templateByte(body []byte) (*template.Template, error) {
+	return templateString(string(body))
+}
+
+// Validate headers and body of request. If they not consist any template
+// return ErrNoTmpl.
+func Validate(req *http.Request, body []byte) error {
+	i := 0
+
+	_, err := templateByte(body)
+	if err != ErrUnknownsTmpl {
+		i++
+	}
+
+	for key := range req.Header {
+		value := req.Header.Get(key)
+
+		_, err1 := templateString(value)
+		if err1 != ErrUnknownsTmpl {
+			i++
+		}
+	}
+
+	if i == len(req.Header) {
+		return ErrUnknownsTmpl
+	}
+
+	return nil
+}
+
+func fillTemplate(tmpl *template.Template) (string, error) {
+	tmplItems := make(map[string]string)
+	for _, node := range ListTemplFields(tmpl) {
+		tmplItem := nodeToTemplateItem(node)
+		if tmplItem == Unknown {
+			continue
+		}
+
+		key := strings.TrimLeft(node, "{{.")
+		key = strings.TrimRight(key, "}}")
+		tmplItems[key] = tmplItem.Generate()
+	}
+
+	var b bytes.Buffer
+	err := tmpl.Execute(&b, &tmplItems)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+// FillOut fill out templates in headers and body of request with random values
+func FillOut(r *http.Request, body []byte) (req *http.Request) {
+	r2 := new(http.Request)
+	*r2 = *r
+
+	tmplBody, err := templateByte(body)
+	if err == nil {
+		bodyString, err1 := fillTemplate(tmplBody)
+		if err1 == nil {
+			r2.ContentLength = int64(len(bodyString))
+			r2.Body = ioutil.NopCloser(bytes.NewReader([]byte(bodyString)))
+		}
+	} else {
+		r2.Body = ioutil.NopCloser(bytes.NewReader(body))
+	}
+
+	r2.Header = make(http.Header, len(r.Header))
+
+	for k, s := range r.Header {
+		value := r.Header.Get(k)
+
+		tmplHeader, err := templateString(value)
+		if err != nil {
+			r2.Header[k] = append([]string(nil), s...)
+			continue
+		}
+
+		headerString, err := fillTemplate(tmplHeader)
+		if err == nil {
+			r2.Header[k] = append([]string(nil), []string{headerString}...)
+		}
+	}
+
+	return r2
+}


### PR DESCRIPTION
For testing some POST/PUT-endpoints, it is necessary to use unique values in the request body. For example:
POST-request {"user_email": "test@test.com", "user_password": "123456qwerty"} to http://server.com/api/user for creating the user.
Now we cannot apply hey for this case, because user_email in each request must be unique.
Adding templates can help us execute requests. During handling of request, the markers in the template will be replaced with random values ​​that differ for different markers.
For our example, we need to use the following template:
{"user_email": "{{.Email}}", "user_password": "{{.String}}"}
A random email address will be generated on the Email marker, e.g. gyf4ws3e2f@og9vu.com.
In request may be multiple markers, e.g. {"primary_email": "{{.Email_1}}", "secondary_email": "{{.Email_2}}"}

In other cases, you may need random integers, strings, float, date/time/datetime.
In header necessary to generate the RequestID. 