### PR TITLE
Fix DNS dialup detailed output in print.go

### DIFF
--- a/requester/print.go
+++ b/requester/print.go
@@ -111,7 +111,7 @@ Latency distribution:{{ range .LatencyDistribution }}
   {{ .Percentage }}%% in {{ formatNumber .Latency }} secs{{ end }}
 
 Details (average, fastest, slowest):
-  DNS+dialup:	{{ formatNumber .AvgConn }} secs, {{ formatNumber .Fastest }} secs, {{ formatNumber .Slowest }} secs
+  DNS+dialup:	{{ formatNumber .AvgConn }} secs, {{ formatNumber .ConnMax }} secs, {{ formatNumber .ConnMin }} secs
   DNS-lookup:	{{ formatNumber .AvgDNS }} secs, {{ formatNumber .DnsMax }} secs, {{ formatNumber .DnsMin }} secs
   req write:	{{ formatNumber .AvgReq }} secs, {{ formatNumber .ReqMax }} secs, {{ formatNumber .ReqMin }} secs
   resp wait:	{{ formatNumber .AvgDelay }} secs, {{ formatNumber .DelayMax }} secs, {{ formatNumber .DelayMin }} secs


### PR DESCRIPTION
This addresses a bug that had the default 'Details' output showing the total fastest and total slowest request times in the DNS dialup min / max categories.
