### PR TITLE
Fix User-Agent set with headers

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -203,11 +203,12 @@ func main() {
 		req.Host = *hostHeader
 	}
 
-	ua := req.UserAgent()
-	if ua == "" {
-		ua = heyUA
+	var ua string
+	// Set by command line `hey -H "User-Agent: CustomUserAgent"`
+	if header.Get("User-Agent") != "" {
+		ua = header.Get("User-Agent")
 	} else {
-		ua += " " + heyUA
+		ua = heyUA
 	}
 	header.Set("User-Agent", ua)
 	req.Header = header


### PR DESCRIPTION
on command line the option -H "User-Agent: CustomUserAgent"
is ignored and default user agent is always used
First check if its defined then fallback to default

ref https://github.com/rakyll/hey/pull/87
fix https://github.com/rakyll/hey/issues/157

Other tools like curl and w3m allow this let me know if its clean go