### PR TITLE
prevent panics when a RequestFunc rather than a Request is passed in

### DIFF
--- a/requester/requester.go
+++ b/requester/requester.go
@@ -238,7 +238,6 @@ func (b *Work) runWorkers() {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
-			ServerName:         b.Request.Host,
 		},
 		MaxIdleConnsPerHost: min(b.C, maxIdleConn),
 		DisableCompression:  b.DisableCompression,


### PR DESCRIPTION
When clients set up a `requester.Work` with a `RequestFunc` instead of a `Request`, we panic because we try to access the Host field on a nil Request.

I think we can omit setting the `TLSClientConfig.ServerName` since there seems to be a fallback for that.

I also added a test for `RequestFunc`