### PR TITLE
Trim header name, if present, from flag -T value

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -141,8 +141,11 @@ func main() {
 	method := strings.ToUpper(*m)
 
 	// set content-type
+	// trim content-type if present in flag
+	ct := strings.TrimPrefix(*contentType, "Content-Type:")
+	ct = strings.TrimSpace(ct)
 	header := make(http.Header)
-	header.Set("Content-Type", *contentType)
+	header.Set("Content-Type", ct)
 	// set any other additional headers
 	if *headers != "" {
 		usageAndExit("Flag '-h' is deprecated, please use '-H' instead.")


### PR DESCRIPTION
Prevents content-type duplication.  If the header name is present, it will be removed from the value provided in flag -T.

Currently an invocation like: `hey -m POST -T 'Content-Type: application/json' -d '{"foo": "bar"}' http://localhost`  will make the header be set to `'Content-Type:Content-Type: application/json'`

The introduced change fixes the user mistake by deduplicating `"Content-Type"`  so the above example produces the intended request.

Hope this prevents unnecessary headaches for users :)




