### PR TITLE
add go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: go
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Setup Go
+      uses: actions/setup-go@v2
+    - name: Build with make
+      run: make
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Setup Go
+      uses: actions/setup-go@v2
+    - name: Go test
+      run: go test -v -cover ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-dist: bionic
-language: go
-go:
-  - "1.13"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ![hey](http://i.imgur.com/szzD9q0.png)
 
-[![Build Status](https://travis-ci.org/rakyll/hey.svg?branch=master)](https://travis-ci.org/rakyll/hey)
-
 hey is a tiny program that sends some load to a web application.
 
 hey was originally called boom and was influenced from Tarek Ziade's

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![hey](http://i.imgur.com/szzD9q0.png)
 
+[![go](https://github.com/rakyll/hey/actions/workflows/go.yml/badge.svg)](https://github.com/rakyll/hey/actions/workflows/go.yml)
+
 hey is a tiny program that sends some load to a web application.
 
 hey was originally called boom and was influenced from Tarek Ziade's


### PR DESCRIPTION
I've been using `hey` recently and it seems pretty nifty, but I noticed there haven't been any Travis CI job status updates to this repo since February 2020. A Travis CI [blog post](https://blog.travis-ci.com/2021-05-07-orgshutdown) mentions an upcoming migration from travis-ci.org to travis-ci.com, but not sure if that is related to the problem.

In this PR I've put together a simple [workflow](https://docs.github.com/en/actions) using GitHub's [Setup go environment](https://github.com/marketplace/actions/setup-go-environment) action to do what the Travis CI job use to do, which was build the binaries using `make`, and also run `go test` unit tests. They run in parallel and total time should usually be less than 1 minute.

Feel free to close this PR if not desired.