### PR TITLE
Exit early if flags are passed after URL

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -112,7 +112,7 @@ func main() {
 	flag.Var(&hs, "H", "")
 
 	flag.Parse()
-	if flag.NArg() < 1 {
+	if flag.NArg() != 1 {
 		usageAndExit("")
 	}
 


### PR DESCRIPTION
Go's flag package expects all flags to come before positional arguments. 
`hey https://example.com -n 1` currently behaves like `hey https://example.com`, which is a bit unexpected. 
This commit changes this behavior to exit and show usage information instead.

Thanks for maintaining hey, it has been super useful to me! 😃 