### PR TITLE
Write Keylog File - TLS Debugging

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -93,7 +93,7 @@ Options:
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
   -h2 Enable HTTP/2.
-	-k  Enable keylog writer for decrypting TLS in a network traffic capture. INSECURE; only used for debugging. Example: -k <file>
+  -k  Enable keylog writer for decrypting TLS in a network traffic capture. INSECURE; only used for debugging. Example: -k <file>
 
   -host	HTTP Host header.
 

--- a/hey.go
+++ b/hey.go
@@ -48,6 +48,7 @@ var (
 	authHeader  = flag.String("a", "", "")
 	hostHeader  = flag.String("host", "", "")
 	userAgent   = flag.String("U", "", "")
+	keyLogFile  = flag.String("k", "", "")
 
 	output = flag.String("o", "", "")
 
@@ -92,6 +93,7 @@ Options:
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
   -h2 Enable HTTP/2.
+	-k  Enable keylog writer for decrypting TLS in a network traffic capture. INSECURE; only used for debugging. Example: -k <file>
 
   -host	HTTP Host header.
 
@@ -232,6 +234,7 @@ func main() {
 		DisableKeepAlives:  *disableKeepAlives,
 		DisableRedirects:   *disableRedirects,
 		H2:                 *h2,
+		KeyLogFile:         *keyLogFile,
 		ProxyAddr:          proxyURL,
 		Output:             *output,
 	}

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -244,7 +244,8 @@ func (b *Work) runWorkers() {
 		log.Printf("!!!!! WARNING !!!!! Logging TLS secrets to %v. Your TLS traffic can be decrypted with this file.", b.KeyLogFile)
 
 		var err error
-		keyLogWriter, err = os.OpenFile(b.KeyLogFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+		// Append so that you can run `hey` multiple times and still log to a single keyfile
+		keyLogWriter, err = os.OpenFile(b.KeyLogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 
 		if err != nil {
 			log.Fatalf("Failed to open keylog file for writing: %v", err)


### PR DESCRIPTION
This PR adds a `-k` option to enable [key log file](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format) writing which can be used in conjunction with `tcpdump`/Wireshark to [decrypt TLS traffic](https://wiki.wireshark.org/TLS) from your tests.

I personally found this useful for debugging timings on connections, and used it in my local testing in conjunction with my other PR to pin TLS versions and compare timings on TLS 1.2 vs TLS 1.3.