### PR TITLE
fix: Authorization header is abandoned because of the req.Header = he…

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -198,6 +198,7 @@ func main() {
 	req.ContentLength = int64(len(bodyAll))
 	if username != "" || password != "" {
 		req.SetBasicAuth(username, password)
+		header.Set("Authorization", req.Header.Get("Authorization"))
 	}
 
 	// set host header if set


### PR DESCRIPTION
the Authorization header is abort by req.Header = header in line 223 of hey.go