### PR TITLE
Fix: Prevent Authorization header removal

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -196,9 +196,6 @@ func main() {
 		usageAndExit(err.Error())
 	}
 	req.ContentLength = int64(len(bodyAll))
-	if username != "" || password != "" {
-		req.SetBasicAuth(username, password)
-	}
 
 	// set host header if set
 	if *hostHeader != "" {
@@ -220,6 +217,10 @@ func main() {
 	}
 
 	req.Header = header
+
+	if username != "" || password != "" {
+		req.SetBasicAuth(username, password)
+	}
 
 	w := &requester.Work{
 		Request:            req,


### PR DESCRIPTION
The `req.SetBasicAuth()` function must be invoked after setting the request headers (line: `req.Header = header`). Otherwise, the `Authorization` header will be cleared before the request is sent, resulting in an HTTP 401 error from the upstream server.