### PR TITLE
fix: default the retrieval of the Host header if passed using -H

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -201,6 +201,7 @@ func main() {
 	}
 
 	// set host header if set
+	req.Host = header.Get("Host")
 	if *hostHeader != "" {
 		req.Host = *hostHeader
 	}


### PR DESCRIPTION
Defaults the host header to the one passed using the -H option

Signed-off-by: Shashank Murthy <shashank.murthy@olacabs.com>