### PR TITLE
Added FreeBSD as a supported compiled binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,4 @@ release:
 	GOOS=windows GOARCH=amd64 go build -o ./bin/$(binary)_windows_amd64
 	GOOS=linux GOARCH=amd64 go build -o ./bin/$(binary)_linux_amd64
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/$(binary)_darwin_amd64
+	GOOS=freebsd GOARCH=amd64 go build -o ./bin/$(binary)_freebsd_amd64


### PR DESCRIPTION
Makefile modified with the following:
`GOOS=freebsd GOARCH=amd64 go build -o ./bin/$(binary)_freebsd_amd64`

Compilation tested successfully on a FreeBSD 13.0 Release build. 