### PR TITLE
Update deps for existing vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rakyll/hey
 
 require (
-	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb
-	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
+	golang.org/x/net v0.0.0-20220907135653-1e95f45603a7
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,15 @@
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20191009170851-d66e71096ffb h1:TR699M2v0qoKTOHxeLgp6zPqaQNs74f01a/ob9W0qko=
 golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20220907135653-1e95f45603a7 h1:1WGATo9HAhkWMbfyuVU0tEFP88OIkUvwaHFveQPvzCQ=
+golang.org/x/net v0.0.0-20220907135653-1e95f45603a7/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
## Details
Scanning for dependencies with known vulnerabilities...
Found 1 known vulnerability.

#### Vulnerability 1: GO-2022-0236
  A malicious HTTP server or client can cause the net/http client
  or server to panic. ReadRequest and ReadResponse can hit an
  unrecoverable panic when reading a very large header (over 7MB
  on 64-bit architectures, or over 4MB on 32-bit ones). Transport
  and Client are vulnerable and the program can be made to crash
  by a malicious server. Server is not vulnerable by default, but
  can be if the default max header of 1MB is overridden by setting
  Server.MaxHeaderBytes to a higher value, in which case the
  program can be made to crash by a malicious client. This also
  affects golang.org/x/net/http2/h2c and HeaderValuesContainsToken
  in golang.org/x/net/http/httpguts.

  Call stacks in your code:
      requester/requester.go:185:19: github.com/rakyll/hey/requester.Work.makeRequest calls net/http.Client.Do, which eventually calls golang.org/x/net/http/httpguts.HeaderValuesContainsToken

  Found in: golang.org/x/net/http/httpguts@v0.0.0-20191009170851-d66e71096ffb
  Fixed in: golang.org/x/net/http/httpguts@v1.16.4
  More info: https://pkg.go.dev/vuln/GO-2022-0236

### Informational

The vulnerabilities below are in packages that you import, but your code
doesn't appear to call any vulnerable functions. You may not need to take any
action. See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
for details.

#### Vulnerability 1: GO-2022-0288
  An attacker can cause unbounded memory growth in servers accepting
  HTTP/2 requests.

  Found in: golang.org/x/net/http2@v0.0.0-20191009170851-d66e71096ffb
  Fixed in: golang.org/x/net/http2@v1.17.5
  More info: https://pkg.go.dev/vuln/GO-2022-0288

### Vulnerability 2: GO-2020-0015
  An attacker could provide a single byte to a UTF16 decoder instantiated with
  UseBOM or ExpectBOM to trigger an infinite loop if the String function on
  the Decoder is called, or the Decoder is passed to transform.String.
  If used to parse user supplied input, this may be used as a denial of service
  vector.

  Found in: golang.org/x/text/transform@v0.3.2
  Fixed in: golang.org/x/text/transform@v0.3.3
  More info: https://pkg.go.dev/vuln/GO-2020-0015

## Test

```
$ go test ./...
ok  	github.com/rakyll/hey	0.114s
ok  	github.com/rakyll/hey/requester	1.203s
```

## Build

```
$ go build && ./hey -n 1 -c 1 https://jsonplaceholder.typicode.com/todos/1

Summary:
  Total:	0.3961 secs
  Slowest:	0.3961 secs
  Fastest:	0.3961 secs
  Average:	0.3961 secs
  Requests/sec:	2.5247


Response time histogram:
  0.396 [1]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.396 [0]	|
  0.396 [0]	|
  0.396 [0]	|
  0.396 [0]	|
  0.396 [0]	|
  0.396 [0]	|
  0.396 [0]	|
  0.396 [0]	|
  0.396 [0]	|
  0.396 [0]	|


Latency distribution:
  0% in 0.0000 secs
  0% in 0.0000 secs
  0% in 0.0000 secs
  0% in 0.0000 secs
  0% in 0.0000 secs
  0% in 0.0000 secs
  0% in 0.0000 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.3557 secs, 0.3557 secs, 0.3557 secs
  DNS-lookup:	0.0087 secs, 0.0087 secs, 0.0087 secs
  req write:	0.0001 secs, 0.0001 secs, 0.0001 secs
  resp wait:	0.0400 secs, 0.0400 secs, 0.0400 secs
  resp read:	0.0003 secs, 0.0003 secs, 0.0003 secs

Status code distribution:
  [200]	1 responses
```