### PR TITLE
Remove port number from host when setting server_name

### DIFF
--- a/requester/requester.go
+++ b/requester/requester.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
@@ -235,10 +236,11 @@ func (b *Work) runWorkers() {
 	var wg sync.WaitGroup
 	wg.Add(b.C)
 
+	hostNoPort, _, _ := net.SplitHostPort(b.Request.Host)
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
-			ServerName:         b.Request.Host,
+			ServerName:         hostNoPort,
 		},
 		MaxIdleConnsPerHost: min(b.C, maxIdleConn),
 		DisableCompression:  b.DisableCompression,


### PR DESCRIPTION
SNI supports only DNS hostnames for the server names https://datatracker.ietf.org/doc/html/rfc3546#section-3.1

Removes port number from the hostname if the hostname has port