### PR TITLE
Feature: randomly select request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rakyll/hey
+module github.com/lakeraai/hey
 
 require (
 	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -276,6 +276,8 @@ func CloneRequest(r *http.Request, body []byte) *http.Request {
 	if len(body) > 0 {
 		r2.Body = ioutil.NopCloser(bytes.NewReader(body))
 	}
+	r2.ContentLength = int64(len(body))
+
 	return r2
 }
 

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -154,7 +154,7 @@ func (b *Work) makeRequest(c *http.Client) {
 	if b.RequestFunc != nil {
 		req = b.RequestFunc()
 	} else {
-		req = cloneRequest(b.Request, b.RequestBody)
+		req = CloneRequest(b.Request, b.RequestBody)
 	}
 	trace := &httptrace.ClientTrace{
 		DNSStart: func(info httptrace.DNSStartInfo) {
@@ -262,9 +262,9 @@ func (b *Work) runWorkers() {
 	wg.Wait()
 }
 
-// cloneRequest returns a clone of the provided *http.Request.
+// CloneRequest returns a clone of the provided *http.Request.
 // The clone is a shallow copy of the struct and its Header map.
-func cloneRequest(r *http.Request, body []byte) *http.Request {
+func CloneRequest(r *http.Request, body []byte) *http.Request {
 	// shallow copy of the struct
 	r2 := new(http.Request)
 	*r2 = *r


### PR DESCRIPTION
If `-r` flag is specified, the request from `-d` or `-D` is split by endline characters and random line is used as request for every worker.

Note that randomization here is non-deterministic. We can change it later if we need to.

Also we can adjust `report.go` and `pring.go` to add some stats on average length of request generated etc.