### PR TITLE
Dockerfile: Set `DEBIAN_FRONTEND=noninteractive`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y ca-certificates
 RUN go get github.com/rakyll/hey
 


### PR DESCRIPTION
From `man 7 debconf`:
```
       noninteractive
              This is the anti-frontend. It never interacts with you at all, and makes the default answers be used for all questions.
              It  might  mail  error  messages  to  root, but that's it; otherwise it is completely silent and unobtrusive, a perfect
              frontend for automatic installs. If you are using this front-end, and require non-default  answers  to  questions,  you
              will need to preseed the debconf database; see the section below on Unattended Package Installation for more details.
```