### PR TITLE
feat: Support an option to skip certificate verification

### DIFF
--- a/hey.go
+++ b/hey.go
@@ -93,7 +93,7 @@ Options:
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
   -h2 Enable HTTP/2.
-  -k  Skip verify insecure TLS certs.
+  -k  Skip certificate verification.
 
   -host	HTTP Host header.
 

--- a/hey.go
+++ b/hey.go
@@ -58,6 +58,7 @@ var (
 	z = flag.Duration("z", 0, "")
 
 	h2   = flag.Bool("h2", false, "")
+	k    = flag.Bool("k", false, "")
 	cpus = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
 
 	disableCompression = flag.Bool("disable-compression", false, "")
@@ -92,6 +93,7 @@ Options:
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
   -h2 Enable HTTP/2.
+  -k  Skip verify insecure TLS certs.
 
   -host	HTTP Host header.
 
@@ -226,6 +228,7 @@ func main() {
 		RequestBody:        bodyAll,
 		N:                  num,
 		C:                  conc,
+		K:                  *k,
 		QPS:                q,
 		Timeout:            *t,
 		DisableCompression: *disableCompression,

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -66,6 +66,9 @@ type Work struct {
 	// H2 is an option to make HTTP/2 requests
 	H2 bool
 
+	// K is an option to Skip verify insecure TLS certs.
+	K bool
+
 	// Timeout in seconds.
 	Timeout int
 
@@ -237,7 +240,7 @@ func (b *Work) runWorkers() {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: b.K,
 			ServerName:         b.Request.Host,
 		},
 		MaxIdleConnsPerHost: min(b.C, maxIdleConn),

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -66,7 +66,7 @@ type Work struct {
 	// H2 is an option to make HTTP/2 requests
 	H2 bool
 
-	// K is an option to Skip verify insecure TLS certs.
+	// K is an option to skip certificate verification.
 	K bool
 
 	// Timeout in seconds.


### PR DESCRIPTION
Supported an option to skip certificate verification, resolving issues where calls could not be initiated in scenarios such as self-signed certificates.