### PR TITLE
Add TLS flags

### DIFF
--- a/requester/requester.go
+++ b/requester/requester.go
@@ -47,6 +47,8 @@ type result struct {
 }
 
 type Work struct {
+	// TLS configuration for the HTTP transport.
+	TLSConfig *tls.Config
 	// Request is the request to be made.
 	Request *http.Request
 
@@ -237,10 +239,7 @@ func (b *Work) runWorkers() {
 	wg.Add(b.C)
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-			ServerName:         b.Request.Host,
-		},
+		TLSClientConfig:     b.TLSConfig,
 		MaxIdleConnsPerHost: min(b.C, maxIdleConn),
 		DisableCompression:  b.DisableCompression,
 		DisableKeepAlives:   b.DisableKeepAlives,
@@ -271,4 +270,3 @@ func cloneRequest(r *http.Request, body []byte) *http.Request {
 	}
 	return r2
 }
-


### PR DESCRIPTION
Hello, not sure if this contribution will be welcome, but I really like `hey` and these changes helped me benchmark an mTLS endpoint recently. Happy to address any issues if needed.

Add TLS flags

- `-insecure` to enable `InsecureSkipVerify`
- `-ca` to load a custom CA certificate chain
- `-cert`/`-key` to load a custom certificate keypair, useful for mTLS

Related to [!303](https://github.com/rakyll/hey/issues/303)